### PR TITLE
[Linalg] fix element-fusion for multi-operands from the same producer

### DIFF
--- a/compiler/test/Dialect/Linalg/linalg-fuse-elementwise-ext-existing.mlir
+++ b/compiler/test/Dialect/Linalg/linalg-fuse-elementwise-ext-existing.mlir
@@ -482,13 +482,13 @@ func.func @one_dim_indexed_producer_consumer_fusion(%arg0 : tensor<?xi32>,
 //   CHECK-DAG: #[[$MAP1:.*]] = affine_map<(d0, d1) -> (d1)>
 // CHECK-LABEL: func @one_dim_indexed_producer_consumer_fusion
 //       CHECK: linalg.generic
-// CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP0]]]
+// CHECK-SAME:    indexing_maps = [#[[$MAP1]], #[[$MAP0]], #[[$MAP0]]]
 //      CHECK: ^{{[a-zA-Z0-9_]*}}
 // CHECK-SAME: (%[[ARG0:[a-zA-Z0-9_]*]]: i32, %[[ARG1:[a-zA-Z0-9_]*]]: i32
 //      CHECK:   %[[IDX1:.+]] = linalg.index 1 : index
 //      CHECK:   %[[VAL1:.+]] = arith.index_cast %[[IDX1]] : index to i32
-//      CHECK:   %[[VAL2:.+]] = arith.addi %[[ARG1]], %[[VAL1]] : i32
-//      CHECK:   %[[VAL3:.+]] = arith.addi %[[ARG0]], %[[VAL2]] : i32
+//      CHECK:   %[[VAL2:.+]] = arith.addi %[[ARG0]], %[[VAL1]] : i32
+//      CHECK:   %[[VAL3:.+]] = arith.addi %[[ARG1]], %[[VAL2]] : i32
 //      CHECK:   linalg.yield %[[VAL3]] : i32
 //   CHECK-NOT: linalg.generic
 


### PR DESCRIPTION
Before this patch, when applying `-linalg-fuse-elementwise-ext -cse` on 

```
#map = affine_map<(d0, d1) -> (d0, d1)>

func.func @consumer_multi_result_from_producer(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4xf32>) -> (tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>) {
  %0 = tensor.empty() : tensor<2x4xf32>
  %1 = tensor.empty() : tensor<2x4xf32>
  %2 = tensor.empty() : tensor<2x4xf32>
  %3 = tensor.empty() : tensor<2x4xf32>
  %4:3 = linalg.generic {indexing_maps = [#map, #map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<2x4xf32>, tensor<2x4xf32>) outs(%0, %1, %3 : tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>) {
  ^bb0(%in: f32, %in_0: f32, %out: f32, %out_1: f32, %out_2: f32):
    %6 = arith.maxf %in, %in_0 : f32
    %7 = arith.minf %in, %in_0 : f32
    %8 = arith.addf %7, %in_0 : f32
    linalg.yield %7, %8, %6 : f32, f32, f32
  } -> (tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>)
  %5 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%4#1, %4#0 : tensor<2x4xf32>, tensor<2x4xf32>) outs(%2 : tensor<2x4xf32>) {
  ^bb0(%in: f32, %in_0: f32, %out: f32):
    %6 = arith.mulf %in, %in_0 : f32
    linalg.yield %6 : f32
  } -> tensor<2x4xf32>
  return %4#1, %4#2, %5 : tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>
}
```

will get 

```
#map = affine_map<(d0, d1) -> (d0, d1)>
module {
  func.func @consumer_multi_result_from_producer(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4xf32>) -> (tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>) {
    %0 = tensor.empty() : tensor<2x4xf32>
    %1:2 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<2x4xf32>, tensor<2x4xf32>) outs(%0, %0 : tensor<2x4xf32>, tensor<2x4xf32>) {
    ^bb0(%in: f32, %in_0: f32, %out: f32, %out_1: f32):
      %2 = arith.minf %in, %in_0 : f32
      %3 = arith.maxf %in, %in_0 : f32
      %4 = arith.addf %2, %in_0 : f32
      %5 = arith.mulf %4, %2 : f32
      linalg.yield %3, %5 : f32, f32
    } -> (tensor<2x4xf32>, tensor<2x4xf32>)
    return %1#0, %1#1, %1#1 : tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>
  }
}

```

which is wrong.