### PR TITLE
[Compiler/mhlo] changed implicit cast to explicit one due to a Mac clang error

### DIFF
--- a/compiler/lib/Dialect/mhlo/Transforms/HloFolder.cpp
+++ b/compiler/lib/Dialect/mhlo/Transforms/HloFolder.cpp
@@ -320,7 +320,7 @@ struct ConvOrDotWithBiasFollowedByBroadcastPattern<
 
       BroadcastInDimOp newBroadInDimOp = builder.create<mhlo::BroadcastInDimOp>(
           constOp->getLoc(), weightType, constOp.getOutput(),
-          rewriter.getI64TensorAttr({weightFeatureDim}));
+          rewriter.getI64TensorAttr({static_cast<int64_t>(weightFeatureDim)}));
       MulOp newMulOp = builder.create<MulOp>(constOp->getLoc(), weight,
                                              newBroadInDimOp->getResult(0));
       convOrDotOp->setOperand(1, newMulOp->getResult(0));


### PR DESCRIPTION
Fixed a error from Mac env. 

error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'long long' in initializer list [-Wc++11-narrowing]