### PR TITLE
Fix explicit instantiation of template functions

### DIFF
--- a/compiler/lib/Dialect/mhlo/Util/Util.cpp
+++ b/compiler/lib/Dialect/mhlo/Util/Util.cpp
@@ -250,8 +250,10 @@ template <typename OpTy> bool mlir::isValidPoolOrPoolGradLayout(OpTy op) {
   return true;
 }
 
-template bool isValidPoolOrPoolGradLayout(mlir::mhlo::ReduceWindowOp);
-template bool isValidPoolOrPoolGradLayout(mlir::mhlo::SelectAndScatterOp);
+namespace mlir {
+template bool isValidPoolOrPoolGradLayout(mhlo::ReduceWindowOp);
+template bool isValidPoolOrPoolGradLayout(mhlo::SelectAndScatterOp);
+} // namespace mlir
 
 byteir::NamedLayout mlir::getPoolLayout(mlir::mhlo::ReduceWindowOp op) {
   if (!mlir::isValidPoolOrPoolGradLayout(op)) {


### PR DESCRIPTION
With clag 15 you would get
```
error: explicit instantiation of 'mlir::isValidPoolOrPoolGradLayout' must occur in namespace 'mlir'
```
See: https://docwiki.embarcadero.com/RADStudio/Alexandria/en/Explicit_instantiation_of_%27namespace::templated_class%27_must_occur_in_namespace_%27namespace%27_(C%2B%2B)

This PR fixes this error.