### PR TITLE
Replace pull_request with pull_request_target to make pull requests from forks work 

### DIFF
--- a/.github/workflows/compiler-and-runtime-build.yml
+++ b/.github/workflows/compiler-and-runtime-build.yml
@@ -8,7 +8,6 @@ on:
       - "frontends/**"
       - "scripts/frontends/**"
   pull_request_target:
-    types: [opened, synchronize, reopened]
     branches:
       - main
     paths-ignore:

--- a/.github/workflows/compiler-and-runtime-build.yml
+++ b/.github/workflows/compiler-and-runtime-build.yml
@@ -34,24 +34,12 @@ jobs:
     runs-on: self-hosted
     needs: [clear_workspace]
     steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
+      - name: Approve
+        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   byteir_compiler_build_and_test:
     name: byteir compiler build and test
     runs-on: self-hosted
+    environment: github-ci
     needs: [check_permission]
     steps:
       - name: Checkout byteir repo
@@ -64,6 +52,7 @@ jobs:
   brt_check_cpu:
     name: BRT cpu test
     runs-on: self-hosted
+    environment: github-ci
     needs: [check_permission]
     steps:
     - name: Checkout byteir repo
@@ -79,6 +68,7 @@ jobs:
   brt_check_cuda:
     name: BRT CUDA test
     runs-on: self-hosted
+    environment: github-ci
     needs: [check_permission]
     steps:
     - name: Checkout byteir repo
@@ -91,6 +81,7 @@ jobs:
   brt_check_asan:
     name: BRT test with asan
     runs-on: self-hosted
+    environment: github-ci
     needs: [check_permission]
     steps:
     - name: Checkout byteir repo
@@ -103,6 +94,7 @@ jobs:
   byteir_compiler_build_and_test_python:
     name: byteir cat test CI
     runs-on: self-hosted
+    environment: github-ci
     needs: [check_permission]
     steps:
     - name: Checkout byteir repo

--- a/.github/workflows/compiler-and-runtime-build.yml
+++ b/.github/workflows/compiler-and-runtime-build.yml
@@ -7,7 +7,8 @@ on:
     paths-ignore:
       - "frontends/**"
       - "scripts/frontends/**"
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
       - main
     paths-ignore:
@@ -30,23 +31,46 @@ jobs:
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
-  byteir_compiler_build_and_test:
-    name: byteir compiler build and test
+  check_permission:
     runs-on: self-hosted
     needs: [clear_workspace]
     steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+  byteir_compiler_build_and_test:
+    name: byteir compiler build and test
+    runs-on: self-hosted
+    needs: [check_permission]
+    steps:
       - name: Checkout byteir repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Run build and test
         run: ./scripts/compiler/build_and_lit_test.sh ${{ secrets.LLVM_INSTALL_DIR }}
         shell: bash
   brt_check_cpu:
     name: BRT cpu test
     runs-on: self-hosted
-    needs: [clear_workspace]
+    needs: [check_permission]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and test BRT
       run: ./scripts/runtime/build_and_test.sh --python ${{ secrets.LLVM_INSTALL_DIR }}
       shell: bash
@@ -56,30 +80,36 @@ jobs:
   brt_check_cuda:
     name: BRT CUDA test
     runs-on: self-hosted
-    needs: [clear_workspace]
+    needs: [check_permission]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and test BRT with CUDA ON
       run: ./scripts/runtime/build_and_test.sh --cuda --python ${{ secrets.LLVM_INSTALL_DIR }}
       shell: bash
   brt_check_asan:
     name: BRT test with asan
     runs-on: self-hosted
-    needs: [clear_workspace]
+    needs: [check_permission]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and test BRT with asan
       run: ./scripts/runtime/build_and_test.sh --cuda --asan ${{ secrets.LLVM_INSTALL_DIR }}
       shell: bash
   byteir_compiler_build_and_test_python:
     name: byteir cat test CI
     runs-on: self-hosted
-    needs: [clear_workspace]
+    needs: [check_permission]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and Test Python APIs
       run: ./scripts/compiler/build_and_test_cat.sh ${{ secrets.LLVM_INSTALL_DIR }}
       shell: bash

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -18,27 +18,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_permission:
+    runs-on: self-hosted
+    steps:
+      - name: Approve
+        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   numerical_e2e_test:
     name: e2e CI
     runs-on: self-hosted
+    needs: check_permission
+    environment: github-ci
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
       - name: Checkout byteir repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
   workflow_dispatch:
@@ -24,8 +24,25 @@ jobs:
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
       - name: Checkout byteir repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Build and test e2e
         run: ./scripts/e2e/build_and_test_e2e.sh ${{ secrets.LLVM_INSTALL_DIR }} ${{ secrets.TORCH_FRONTEND_LLVM_INSTALL_DIR }}
         shell: bash

--- a/.github/workflows/torch-frontend-ci.yml
+++ b/.github/workflows/torch-frontend-ci.yml
@@ -24,27 +24,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_permission:
+    runs-on: self-hosted
+    steps:
+      - name: Approve
+        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   torch_frontend_build_and_test:
     name: torch-frontend CI
     runs-on: self-hosted
+    needs: check_permission
+    environment: github-ci
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
       - name: Checkout byteir repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/torch-frontend-ci.yml
+++ b/.github/workflows/torch-frontend-ci.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - "frontends/torch-frontend/**"
       - "scripts/frontends/torch-frontend/**"
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -30,8 +30,25 @@ jobs:
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
       - name: Checkout byteir repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Build and test TorchFrontend
         run: ./scripts/frontends/torch-frontend/build_and_test.sh ${{ secrets.TORCH_FRONTEND_LLVM_INSTALL_DIR }}
         shell: bash


### PR DESCRIPTION
I would like to replace pull_request with pull_request_target so that pull requests from forks could work properly. I fix it by adding an environment for deployment. When someone would like to make a pull request from a fork, we would run their code in the environment called github-ci. Maintainers **must** make sure the code is safe to run before approval. Once someone with the access approves the workflow, it will run as usual.

I notice that @zhekunz2 has added a rule to make sure there is only one flow using the same concurrency group. If the workflow gets cancelled accidentally, we could just proceed to the failed action and approve it again to get it started.

The yaml file is not checked into our repo so it doesn't run properly for now, but I test it at https://github.com/Connor-XY/byteir/pull/4 where it shows that when a pull request is opened, all related workflows should be started. The non-admin user could make a pull request from their own fork and the workflows can still run successfully. Once the yaml file is checked in, the tests will run as we expect.