### PR TITLE
[ci] move llvm_path to prepare.sh, remove environment, add daily ci

### DIFF
--- a/.github/workflows/compiler-and-runtime-build.yml
+++ b/.github/workflows/compiler-and-runtime-build.yml
@@ -1,13 +1,13 @@
 name: Compiler And Runtime Build
 
-on: 
+on:
   push:
     branches:
       - main
     paths-ignore:
       - "frontends/**"
       - "scripts/frontends/**"
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths-ignore:
@@ -20,7 +20,11 @@ on:
 # any in-progress jobs in the same github workflow and github
 # ref (e.g. refs/heads/main or refs/pull/<pr_number>/merge).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -30,37 +34,25 @@ jobs:
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
-  check_permission:
-    runs-on: self-hosted
-    needs: [clear_workspace]
-    steps:
-      - name: Approve
-        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   byteir_compiler_build_and_test:
     name: byteir compiler build and test
     runs-on: self-hosted
-    environment: github-ci
-    needs: [check_permission]
+    needs: [clear_workspace]
     steps:
       - name: Checkout byteir repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Run build and test
-        run: ./scripts/compiler/build_and_lit_test.sh ${{ secrets.LLVM_INSTALL_DIR }}
+        run: ./scripts/compiler/build_and_lit_test.sh
         shell: bash
   brt_check_cpu:
     name: BRT cpu test
     runs-on: self-hosted
-    environment: github-ci
-    needs: [check_permission]
+    needs: [clear_workspace]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and test BRT
-      run: ./scripts/runtime/build_and_test.sh --python ${{ secrets.LLVM_INSTALL_DIR }}
+      run: ./scripts/runtime/build_and_test.sh --python
       shell: bash
     - name: Build and test BRT external project
       run: ./scripts/runtime/build_external_project.sh
@@ -68,39 +60,30 @@ jobs:
   brt_check_cuda:
     name: BRT CUDA test
     runs-on: self-hosted
-    environment: github-ci
-    needs: [check_permission]
+    needs: [clear_workspace]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and test BRT with CUDA ON
-      run: ./scripts/runtime/build_and_test.sh --cuda --python ${{ secrets.LLVM_INSTALL_DIR }}
+      run: ./scripts/runtime/build_and_test.sh --cuda --python
       shell: bash
   brt_check_asan:
     name: BRT test with asan
     runs-on: self-hosted
-    environment: github-ci
-    needs: [check_permission]
+    needs: [clear_workspace]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and test BRT with asan
-      run: ./scripts/runtime/build_and_test.sh --cuda --asan ${{ secrets.LLVM_INSTALL_DIR }}
+      run: ./scripts/runtime/build_and_test.sh --cuda --asan
       shell: bash
   byteir_compiler_build_and_test_python:
     name: byteir cat test CI
     runs-on: self-hosted
-    environment: github-ci
-    needs: [check_permission]
+    needs: [clear_workspace]
     steps:
     - name: Checkout byteir repo
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Build and Test Python APIs
-      run: ./scripts/compiler/build_and_test_cat.sh ${{ secrets.LLVM_INSTALL_DIR }}
+      run: ./scripts/compiler/build_and_test_cat.sh
       shell: bash

--- a/.github/workflows/daily_ci.yaml
+++ b/.github/workflows/daily_ci.yaml
@@ -1,0 +1,33 @@
+name: ByteIR Daily CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  clear_workspace:
+    name: Clear workspace
+    runs-on: self-hosted
+    steps:
+      - name: clear workspace
+        run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+  byteir_compiler_build_and_test:
+    name: byteir compiler build and test
+    runs-on: self-hosted
+    needs: [clear_workspace]
+    steps:
+      - name: Checkout byteir repo
+        uses: actions/checkout@v3
+      - name: Run build and test
+        run: ./scripts/compiler/build_and_lit_test.sh
+        shell: bash
+  numerical_e2e_test:
+    name: e2e CI
+    runs-on: self-hosted
+    needs: [clear_workspace]
+    steps:
+      - name: Checkout byteir repo
+        uses: actions/checkout@v3
+      - name: Build and test e2e
+        run: ./scripts/e2e/build_and_test_e2e.sh
+        shell: bash

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,12 +1,22 @@
 name: e2e Numerical test CI
 
-on: 
+on:
   push:
     branches:
       - main
-  pull_request_target:
+    paths-ignore:
+      - "frontends/onnx-frontend/**"
+      - "frontends/tf-frontend/**"
+      - "scripts/frontends/onnx-frontend/**"
+      - "scripts/frontends/tf-frontend/**"
+  pull_request:
     branches:
       - main
+    paths-ignore:
+      - "frontends/onnx-frontend/**"
+      - "frontends/tf-frontend/**"
+      - "scripts/frontends/onnx-frontend/**"
+      - "scripts/frontends/tf-frontend/**"
   workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same
@@ -14,27 +24,22 @@ on:
 # any in-progress jobs in the same github workflow and github
 # ref (e.g. refs/heads/main or refs/pull/<pr_number>/merge).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  check_permission:
-    runs-on: self-hosted
-    steps:
-      - name: Approve
-        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   numerical_e2e_test:
     name: e2e CI
     runs-on: self-hosted
-    needs: check_permission
-    environment: github-ci
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
       - name: Checkout byteir repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Build and test e2e
-        run: ./scripts/e2e/build_and_test_e2e.sh ${{ secrets.LLVM_INSTALL_DIR }} ${{ secrets.TORCH_FRONTEND_LLVM_INSTALL_DIR }}
+        run: ./scripts/e2e/build_and_test_e2e.sh
         shell: bash

--- a/.github/workflows/torch-frontend-ci.yml
+++ b/.github/workflows/torch-frontend-ci.yml
@@ -1,13 +1,13 @@
 name: TorchFrontend CI
 
-on: 
+on:
   push:
     branches:
       - main
     paths:
       - "frontends/torch-frontend/**"
       - "scripts/frontends/torch-frontend/**"
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -20,27 +20,22 @@ on:
 # any in-progress jobs in the same github workflow and github
 # ref (e.g. refs/heads/main or refs/pull/<pr_number>/merge).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  check_permission:
-    runs-on: self-hosted
-    steps:
-      - name: Approve
-        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   torch_frontend_build_and_test:
     name: torch-frontend CI
     runs-on: self-hosted
-    needs: check_permission
-    environment: github-ci
     steps:
       - name: clear workspace
         run: rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
       - name: Checkout byteir repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Build and test TorchFrontend
-        run: ./scripts/frontends/torch-frontend/build_and_test.sh ${{ secrets.TORCH_FRONTEND_LLVM_INSTALL_DIR }}
+        run: ./scripts/frontends/torch-frontend/build_and_test.sh
         shell: bash

--- a/scripts/compiler/build_and_lit_test.sh
+++ b/scripts/compiler/build_and_lit_test.sh
@@ -16,7 +16,6 @@ INSTALL_DIR="$BUILD_DIR/byre_install"
 
 source $CUR_DIR/../prepare.sh
 
-LLVM_INSTALL_DIR="$1"
 prepare_for_compiler
 
 rm -rf "$BUILD_DIR"

--- a/scripts/compiler/build_and_test_cat.sh
+++ b/scripts/compiler/build_and_test_cat.sh
@@ -15,7 +15,6 @@ INSTALL_DIR="$BUILD_DIR/byre_install"
 
 source $CUR_DIR/../prepare.sh
 
-LLVM_INSTALL_DIR="$1"
 prepare_for_compiler
 
 rm -rf "$BUILD_DIR"

--- a/scripts/e2e/build_and_test_e2e.sh
+++ b/scripts/e2e/build_and_test_e2e.sh
@@ -7,17 +7,13 @@ CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # path to byteir root
 ROOT_PROJ_DIR="$CUR_DIR/../.."
 
-LLVM_INSTALL_DIR="$1"
-
-TORCH_FRONTEND_LLVM_INSTALL_DIR="$2"
-
 pushd $ROOT_PROJ_DIR
 # build compiler
-bash scripts/compiler/build_and_lit_test.sh $LLVM_INSTALL_DIR
+bash scripts/compiler/build_and_lit_test.sh
 # build runtime
-bash scripts/runtime/build_and_test.sh --cuda --python --no-test $LLVM_INSTALL_DIR
+bash scripts/runtime/build_and_test.sh --cuda --python --no-test
 # build torch_frontend
-bash scripts/frontends/torch-frontend/build_and_test.sh $TORCH_FRONTEND_LLVM_INSTALL_DIR
+bash scripts/frontends/torch-frontend/build_and_test.sh
 
 pip3 install $ROOT_PROJ_DIR/external/AITemplate/python/dist/*.whl --force-reinstall
 pip3 install $ROOT_PROJ_DIR/compiler/build/python/dist/*.whl --force-reinstall

--- a/scripts/frontends/torch-frontend/build_and_test.sh
+++ b/scripts/frontends/torch-frontend/build_and_test.sh
@@ -12,14 +12,14 @@ PROJ_DIR="$ROOT_PROJ_DIR/frontends/torch-frontend"
 
 source $CUR_DIR/envsetup.sh
 prepare_for_build
-
-LLVM_INSTALL_DIR="$1"
+source $CUR_DIR/../../prepare.sh
+load_pytorch_llvm_prebuilt
 
 pushd $PROJ_DIR
 cmake -S . \
       -B ./build \
       -GNinja \
-      -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir" \
+      -DMLIR_DIR="$TORCH_FRONTEND_LLVM_INSTALL_DIR/lib/cmake/mlir" \
       -DLLVM_EXTERNAL_LIT=$(which lit) \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_C_COMPILER=gcc \

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -25,12 +25,22 @@ function install_aitemplate() {
   popd
 }
 
+function load_llvm_prebuilt() {
+  LLVM_INSTALL_DIR="/data00/llvm_libraries/4592543a01609feb4b3c19e81a9d54743e15e329/llvm_build"
+}
+
+function load_pytorch_llvm_prebuilt() {
+  TORCH_FRONTEND_LLVM_INSTALL_DIR="/data00/llvm_libraries/f7250179e22ce4aab96166493b27223fa28c2181/llvm_build"
+}
+
 function prepare_for_compiler() {
   git submodule update --init --recursive -f external/mlir-hlo external/AITemplate
   apply_aitemplate_patches
   install_aitemplate
+  load_llvm_prebuilt
 }
 
 function prepare_for_runtime() {
   git submodule update --init --recursive -f external/mlir-hlo external/cutlass external/date external/googletest external/pybind11
+  load_llvm_prebuilt
 }

--- a/scripts/runtime/build_and_test.sh
+++ b/scripts/runtime/build_and_test.sh
@@ -58,7 +58,6 @@ BRT_TEST=${BRT_TEST:-ON}
 
 source $CUR_DIR/../prepare.sh
 prepare_for_runtime
-LLVM_INSTALL_DIR="$1"
 
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"


### PR DESCRIPTION
This pull request:
- move llvm path to scripts/prepare.sh
- add daily ci test
- no longer need deployment in the environment 