### PR TITLE
[torch-frontend] add more ops for lowering to ccl dialect

### DIFF
--- a/compiler/dialects/include/byteir/Dialect/Ccl/IR/CclOps.td
+++ b/compiler/dialects/include/byteir/Dialect/Ccl/IR/CclOps.td
@@ -32,11 +32,11 @@ class Ccl_Op<string mnemonic, list<Trait> traits = []> :
     Op<Ccl_Dialect, mnemonic, traits> {
 }
 
-def Ccl_WaitTensorOp : Ccl_Op<"wait_tensor", [Pure,
+def Ccl_WaitOp : Ccl_Op<"wait", [Pure,
     SameOperandsAndResultElementType,
     SameOperandsAndResultShape,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "WaitTensor operator";
+  let summary = "Wait operator";
   let description = [{
     Wait until tensor to be ready after asynchronous ops.
   }];
@@ -82,6 +82,7 @@ def Ccl_AllReduceOp : Ccl_ReplicaGroupsOp<"all_reduce",
   let arguments = (ins
     AnyTensor:$src,
     Optional<AnyTensor>:$dynamic_replica_groups,
+    BoolAttr:$synchronous,
     StrAttr:$reduction,
     OptionalAttr<IndexListArrayAttr>:$replica_groups,
     OptionalAttr<I64Attr>:$unique_id
@@ -111,6 +112,7 @@ def Ccl_AllGatherOp : Ccl_ReplicaGroupsOp<"all_gather", [Pure]> {
   let arguments = (ins
     AnyTensor:$src,
     Optional<AnyTensor>:$dynamic_replica_groups,
+    BoolAttr:$synchronous,
     I64Attr:$axis,
     OptionalAttr<IndexListArrayAttr>:$replica_groups,
     OptionalAttr<I64Attr>:$unique_id
@@ -134,6 +136,7 @@ def Ccl_ReduceScatterOp : Ccl_ReplicaGroupsOp<"reduce_scatter", [Pure]> {
   let arguments = (ins
     AnyTensor:$src,
     Optional<AnyTensor>:$dynamic_replica_groups,
+    BoolAttr:$synchronous,
     StrAttr:$reduction,
     I64Attr:$axis,
     OptionalAttr<IndexListArrayAttr>:$replica_groups,
@@ -158,6 +161,7 @@ def Ccl_AllToAllOp : Ccl_ReplicaGroupsOp<"all_to_all", [Pure]> {
   let arguments = (ins
     AnyTensor:$src,
     Optional<AnyTensor>:$dynamic_replica_groups,
+    BoolAttr:$synchronous,
     I64Attr:$split_axis,
     I64Attr:$concat_axis,
     OptionalAttr<IndexListArrayAttr>:$replica_groups,
@@ -168,5 +172,37 @@ def Ccl_AllToAllOp : Ccl_ReplicaGroupsOp<"all_to_all", [Pure]> {
   let extraClassDeclaration = commonExtraClassDeclaration;
   let hasVerifier = 1;
 }
+
+def Ccl_SendOp : Ccl_Op<"send", [Pure,
+    SameOperandsAndResultElementType,
+    SameOperandsAndResultShape,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Send operator";
+  let description = [{
+    Send `src` tensor to `target_index` device.
+  }];
+
+  let arguments = (ins
+    AnyTensor:$src,
+    BoolAttr:$synchronous,
+    I64Attr:$target_index
+  );
+  let results = (outs AnyTensor:$result);
+}
+
+def Ccl_RecvOp : Ccl_Op<"recv", [Pure]> {
+  let summary = "Recv operator";
+  let description = [{
+    Recv tensor from `source_index`.
+    if dynmaic shape, `shape` should be given.
+  }];
+
+  let arguments = (ins
+    Optional<1DTensorOf<[Index, I64]>>:$shape,
+    BoolAttr:$synchronous,
+    I64Attr:$source_index
+  );
+  let results = (outs AnyTensor:$result);
+} 
 
 #endif // BYTEIR_DIALECT_CCL_CCL_OPS

--- a/compiler/dialects/lib/Dialect/Ccl/IR/CclOps.cpp
+++ b/compiler/dialects/lib/Dialect/Ccl/IR/CclOps.cpp
@@ -75,14 +75,14 @@ void CclDialect::initialize() {
 }
 
 //===----------------------------------------------------------------------===//
-// ccl.wait_tensor
+// ccl.wait
 //===----------------------------------------------------------------------===//
 
 LogicalResult
-WaitTensorOp::inferReturnTypes(MLIRContext *, std::optional<Location> location,
-                               ValueRange operands, DictionaryAttr,
-                               OpaqueProperties, RegionRange,
-                               SmallVectorImpl<Type> &inferredReturnTypes) {
+WaitOp::inferReturnTypes(MLIRContext *, std::optional<Location> location,
+                         ValueRange operands, DictionaryAttr, OpaqueProperties,
+                         RegionRange,
+                         SmallVectorImpl<Type> &inferredReturnTypes) {
   inferredReturnTypes.push_back(operands[0].getType());
   return success();
 }
@@ -142,6 +142,12 @@ LogicalResult AllGatherOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReduceScatterOp::verify() {
+  auto reduction = getReduction();
+  if (reduction != getRedOpSumName() && reduction != getRedOpProdName() &&
+      reduction != getRedOpMinName() && reduction != getRedOpMaxName() &&
+      reduction != getRedOpAvgName()) {
+    return this->emitError("unknown reduction str: ") << reduction;
+  }
   return verifyReplicaGroups(getLoc(), getReplicaGroupsIndices(),
                              getDynamicReplicaGroups());
 }
@@ -153,6 +159,19 @@ LogicalResult ReduceScatterOp::verify() {
 LogicalResult AllToAllOp::verify() {
   return verifyReplicaGroups(getLoc(), getReplicaGroupsIndices(),
                              getDynamicReplicaGroups());
+}
+
+//===----------------------------------------------------------------------===//
+// ccl.send
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SendOp::inferReturnTypes(MLIRContext *, std::optional<Location> location,
+                         ValueRange operands, DictionaryAttr, OpaqueProperties,
+                         RegionRange,
+                         SmallVectorImpl<Type> &inferredReturnTypes) {
+  inferredReturnTypes.push_back(operands[0].getType());
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/lib/Dialect/Ccl/TransformOps/CclTransformOps.cpp
+++ b/compiler/lib/Dialect/Ccl/TransformOps/CclTransformOps.cpp
@@ -52,7 +52,7 @@ transform::DecomposeAllReduceOp::apply(TransformRewriter &rewriter,
     }
     if (!allReduceOp.getSynchronous()) {
       DiagnosedSilenceableFailure diag =
-          emitSilenceableError() << "cll.all_reduce should be synchronous.";
+          emitSilenceableError() << "ccl.all_reduce should be synchronous.";
       return diag;
     }
 

--- a/compiler/lib/Dialect/Ccl/TransformOps/CclTransformOps.cpp
+++ b/compiler/lib/Dialect/Ccl/TransformOps/CclTransformOps.cpp
@@ -50,6 +50,11 @@ transform::DecomposeAllReduceOp::apply(TransformRewriter &rewriter,
           << "target is expected to be of type ccl.all_reduce.";
       return diag;
     }
+    if (!allReduceOp.getSynchronous()) {
+      DiagnosedSilenceableFailure diag =
+          emitSilenceableError() << "cll.all_reduce should be synchronous.";
+      return diag;
+    }
 
     std::optional<SmallVector<ReplicaGroupsIndices, 4>> replicaGroupsIndices =
         allReduceOp.getReplicaGroupsIndices();
@@ -101,12 +106,14 @@ transform::DecomposeAllReduceOp::apply(TransformRewriter &rewriter,
     OpBuilder builder(target);
     ccl::ReduceScatterOp reduceScatterOp = builder.create<ccl::ReduceScatterOp>(
         target->getLoc(), reduceScatterResultType, allReduceOp.getSrc(),
-        /*dynamic_replica_groups*/ nullptr, allReduceOp.getReductionAttr(),
-        getAxisAttr(), allReduceOp.getReplicaGroupsAttr(),
-        allReduceOp.getUniqueIdAttr());
+        /*dynamic_replica_groups*/ nullptr,
+        /*synchronous*/ allReduceOp.getSynchronousAttr(),
+        allReduceOp.getReductionAttr(), getAxisAttr(),
+        allReduceOp.getReplicaGroupsAttr(), allReduceOp.getUniqueIdAttr());
     ccl::AllGatherOp allGatherOp = builder.create<ccl::AllGatherOp>(
         target->getLoc(), oldResultType, reduceScatterOp.getResult(),
-        /*dynamic_replica_groups*/ nullptr, getAxisAttr(),
+        /*dynamic_replica_groups*/ nullptr,
+        /*synchronous*/ allReduceOp.getSynchronousAttr(), getAxisAttr(),
         allReduceOp.getReplicaGroupsAttr(), allReduceOp.getUniqueIdAttr());
     oldResult.replaceAllUsesWith(allGatherOp.getResult());
     target->erase();

--- a/compiler/lib/Dialect/Linalg/TransformOps/LinalgExtTransformOps.cpp
+++ b/compiler/lib/Dialect/Linalg/TransformOps/LinalgExtTransformOps.cpp
@@ -1349,7 +1349,8 @@ DiagnosedSilenceableFailure transform::SharedOutputToDistributedStyleOp::apply(
     parallelBlock->clear();
     builder.setInsertionPointAfterValue(retVal);
     auto allReduceOp = builder.create<ccl::AllReduceOp>(
-        retVal.getLoc(), retVal, /*dynamic_replica_groups*/ nullptr, reduceType,
+        retVal.getLoc(), retVal, /*dynamic_replica_groups*/ nullptr,
+        /*synchronous*/ rewriter.getBoolAttr(true), reduceType,
         /*replica_groups*/ replicaGroupAttrs, /*unique_id*/ nullptr);
 
     // create new merge op

--- a/compiler/lib/Utils/TileUtils.cpp
+++ b/compiler/lib/Utils/TileUtils.cpp
@@ -301,7 +301,8 @@ LogicalResult mlir::yieldTiledValuesForMultiDst(
         // TODO: there might be other types of all reduce
         Value cclRes = b.create<ccl::AllReduceOp>(
             loc, yieldedValue.value(), /*dynamic_replica_groups*/ nullptr,
-            ccl::getRedOpSumName(), /*replica_groups*/ nullptr,
+            /*synchronous*/ true, ccl::getRedOpSumName(),
+            /*replica_groups*/ nullptr,
             /*unique_id*/ nullptr);
         inserts.push_back(cclRes);
       } else {

--- a/compiler/test/Dialect/Ccl/ccl_move_down.mlir
+++ b/compiler/test/Dialect/Ccl/ccl_move_down.mlir
@@ -21,8 +21,8 @@ func.func @decomposed_all_reduce(%arg0: tensor<125x32x15xf32>) -> tensor<125x32x
       %11 = arith.addf %10, %out : f32
       linalg.yield %11 : f32
     } -> tensor<125x32xf32>
-    %7 = "ccl.reduce_scatter"(%6) {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3, 4]]} : (tensor<125x32xf32>) -> tensor<25x32xf32>
-    %8 = "ccl.all_gather"(%7) {axis = 0 : i64, replica_groups = [[0, 1, 2, 3, 4]]} : (tensor<25x32xf32>) -> tensor<125x32xf32>
+    %7 = "ccl.reduce_scatter"(%6) {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3, 4]], synchronous = true} : (tensor<125x32xf32>) -> tensor<25x32xf32>
+    %8 = "ccl.all_gather"(%7) {axis = 0 : i64, replica_groups = [[0, 1, 2, 3, 4]], synchronous = true} : (tensor<25x32xf32>) -> tensor<125x32xf32>
     %9 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%8 : tensor<125x32xf32>) outs(%1 : tensor<125x32xf32>) {
     ^bb0(%in: f32, %out: f32):
       %10 = arith.addf %in, %out : f32
@@ -63,8 +63,8 @@ func.func @decomposed_all_reduce_with_tensor_empty_init_op(%arg0: tensor<125x32x
       %11 = arith.addf %10, %out : f32
       linalg.yield %11 : f32
     } -> tensor<125x32xf32>
-    %7 = "ccl.reduce_scatter"(%6) {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3, 4]]} : (tensor<125x32xf32>) -> tensor<25x32xf32>
-    %8 = "ccl.all_gather"(%7) {axis = 0 : i64, replica_groups = [[0, 1, 2, 3, 4]]} : (tensor<25x32xf32>) -> tensor<125x32xf32>
+    %7 = "ccl.reduce_scatter"(%6) {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3, 4]], synchronous = true} : (tensor<125x32xf32>) -> tensor<25x32xf32>
+    %8 = "ccl.all_gather"(%7) {axis = 0 : i64, replica_groups = [[0, 1, 2, 3, 4]], synchronous = true} : (tensor<25x32xf32>) -> tensor<125x32xf32>
     %9 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%8 : tensor<125x32xf32>) outs(%0 : tensor<125x32xf32>) {
     ^bb0(%in: f32, %out: f32):
       %10 = arith.addf %in, %out : f32
@@ -106,8 +106,8 @@ func.func @user_outside_region_of_all_gather(%arg0: tensor<125x32x15xf32>) -> te
       %11 = arith.addf %10, %out : f32
       linalg.yield %11 : f32
     } -> tensor<125x32xf32>
-    %7 = "ccl.reduce_scatter"(%6) {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3, 4]]} : (tensor<125x32xf32>) -> tensor<25x32xf32>
-    %8 = "ccl.all_gather"(%7) {axis = 0 : i64, replica_groups = [[0, 1, 2, 3, 4]]} : (tensor<25x32xf32>) -> tensor<125x32xf32>
+    %7 = "ccl.reduce_scatter"(%6) {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3, 4]], synchronous = true} : (tensor<125x32xf32>) -> tensor<25x32xf32>
+    %8 = "ccl.all_gather"(%7) {axis = 0 : i64, replica_groups = [[0, 1, 2, 3, 4]], synchronous = true} : (tensor<25x32xf32>) -> tensor<125x32xf32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %8 into %arg2[0, 0] [125, 32] [1, 1] : tensor<125x32xf32> into tensor<125x32xf32>
     }

--- a/compiler/test/Dialect/Ccl/decompose_all_reduce.mlir
+++ b/compiler/test/Dialect/Ccl/decompose_all_reduce.mlir
@@ -3,7 +3,7 @@
 
 func.func @all_reduce(%arg0: tensor<10x32xf32>) -> tensor<10x32xf32> {
   %0 = "ccl.all_reduce"(%arg0)
-    { reduction = "sum", replica_groups = [[0, 1, 2, 3, 4, 5, 6, 7]], unique_id = 0 : i64} : (tensor<10x32xf32>) -> tensor<10x32xf32>
+    { reduction = "sum", replica_groups = [[0, 1, 2, 3, 4, 5, 6, 7]], unique_id = 0 : i64, synchronous = true} : (tensor<10x32xf32>) -> tensor<10x32xf32>
   func.return %0 : tensor<10x32xf32>
 }
 // CHECK-LABEL: func.func @all_reduce

--- a/compiler/test/Dialect/Ccl/invalid.mlir
+++ b/compiler/test/Dialect/Ccl/invalid.mlir
@@ -3,7 +3,7 @@
 func.func @all_reduce_both_dynamic_and_static_replica_groups(%arg0: tensor<10xf32>, %arg1: tensor<2x4xi32>) -> tensor<10xf32> {
   // expected-error@+1 {{dynamic_replica_groups and replica_groups can't exist simultaneously}}
   %0 = "ccl.all_reduce"(%arg0, %arg1) 
-    { reduction = "sum", replica_groups = [[0, 2, 4, 6], [1, 3, 5, 7]]} : (tensor<10xf32>, tensor<2x4xi32>) -> tensor<10xf32>
+    { reduction = "sum", replica_groups = [[0, 2, 4, 6], [1, 3, 5, 7]], synchronous = true} : (tensor<10xf32>, tensor<2x4xi32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }
 
@@ -12,7 +12,7 @@ func.func @all_reduce_both_dynamic_and_static_replica_groups(%arg0: tensor<10xf3
 func.func @all_reduce_wrong_dynamic_replica_groups_rank(%arg0: tensor<10xf32>, %arg1: tensor<2x4x5xi32>) -> tensor<10xf32> {
   // expected-error@+1 {{dynamic_replica_groups's rank should equal to 2}}
   %0 = "ccl.all_reduce"(%arg0, %arg1) 
-    { reduction = "sum" } : (tensor<10xf32>, tensor<2x4x5xi32>) -> tensor<10xf32>
+    { reduction = "sum", synchronous = true } : (tensor<10xf32>, tensor<2x4x5xi32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }
 
@@ -20,6 +20,6 @@ func.func @all_reduce_wrong_dynamic_replica_groups_rank(%arg0: tensor<10xf32>, %
 
 func.func @all_reduce_duplicated_id(%arg0: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{replica id #0 seen more than once}}
-  %0 = "ccl.all_reduce"(%arg0) { reduction = "sum", replica_groups = [[0, 2, 0, 6], [1, 3, 5, 7]]} : (tensor<10xf32>) -> tensor<10xf32>
+  %0 = "ccl.all_reduce"(%arg0) { reduction = "sum", replica_groups = [[0, 2, 0, 6], [1, 3, 5, 7]], synchronous = true} : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }

--- a/compiler/test/Dialect/Ccl/ops.mlir
+++ b/compiler/test/Dialect/Ccl/ops.mlir
@@ -3,34 +3,34 @@
 
 func.func @all_reduce(%arg0: tensor<10xf32>) -> tensor<10xf32> {
   %0 = "ccl.all_reduce"(%arg0)
-    { reduction = "sum", replica_groups = [[0, 2, 4, 6], [1, 3, 5, 7]], unique_id = 0 : i64} : (tensor<10xf32>) -> tensor<10xf32>
+    { reduction = "sum", replica_groups = [[0, 2, 4, 6], [1, 3, 5, 7]], unique_id = 0 : i64, synchronous = true} : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }
 // CHECK-LABEL: func.func @all_reduce
 
 func.func @all_reduce_no_replica_groups(%arg0: tensor<10xf32>) -> tensor<10xf32> {
-  %0 = "ccl.all_reduce"(%arg0) { reduction = "sum", unique_id = 0 : i64} : (tensor<10xf32>) -> tensor<10xf32>
+  %0 = "ccl.all_reduce"(%arg0) { reduction = "sum", unique_id = 0 : i64, synchronous = true} : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }
 // CHECK-LABEL: func.func @all_reduce_no_replica_groups
 
 func.func @all_reduce_different_groups_share_same_replica_id(%arg0: tensor<10xf32>) -> tensor<10xf32> {
   %0 = "ccl.all_reduce"(%arg0)
-    { reduction = "sum", replica_groups = [[0, 2, 4, 6], [0, 3, 5, 7]], unique_id = 0 : i64} : (tensor<10xf32>) -> tensor<10xf32>
+    { reduction = "sum", replica_groups = [[0, 2, 4, 6], [0, 3, 5, 7]], unique_id = 0 : i64, synchronous = true} : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }
 // CHECK-LABEL: func.func @all_reduce_different_groups_share_same_replica_id
 
 func.func @all_gather(%arg0: tensor<16x8xf32>) -> tensor<16x16xf32> {
   %0 = "ccl.all_gather"(%arg0) 
-    { axis = 1 : i64, replica_groups = [[0, 1]], unique_id = 0 : i64} : (tensor<16x8xf32>) -> tensor<16x16xf32>
+    { axis = 1 : i64, replica_groups = [[0, 1]], unique_id = 0 : i64, synchronous = true} : (tensor<16x8xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }
 // CHECK-LABEL: func.func @all_gather
 
 func.func @reduce_scatter(%arg0: tensor<4x16xf32>) -> tensor<4x4xf32> {
   %0 = "ccl.reduce_scatter"(%arg0) 
-  { reduction = "sum", replica_groups = [[0, 1]], axis = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  { reduction = "sum", replica_groups = [[0, 1]], axis = 1 : i64, synchronous = true} : (tensor<4x16xf32>) -> tensor<4x4xf32>
   func.return %0 : tensor<4x4xf32>
 }
 // CHECK-LABEL: func.func @reduce_scatter
@@ -39,7 +39,8 @@ func.func @all_to_all(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
   %0 = "ccl.all_to_all"(%arg0) {
     split_axis = 1 : i64,
     concat_axis = 0 : i64,
-    replica_groups = [[0, 1, 2, 3]]
+    replica_groups = [[0, 1, 2, 3]],
+    synchronous = true
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
   func.return %0 : tensor<16x4xf32>
 }

--- a/frontends/torch-frontend/torch-frontend/lib/Conversion/ConvertTorchToCcl.cpp
+++ b/frontends/torch-frontend/torch-frontend/lib/Conversion/ConvertTorchToCcl.cpp
@@ -18,6 +18,7 @@
 #include "torch-frontend/Conversion/ConvertTorchToCcl.h"
 #include "byteir/Dialect/Ccl/IR/CclOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
@@ -39,7 +40,6 @@ public:
   matchAndRewrite(C10dFunctionalAllReduceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value input = adaptor.getSelf();
-    auto inputType = input.getType();
     auto outType = getTypeConverter()->convertType(op.getResult().getType());
 
     std::string reduceOp, tag;
@@ -59,11 +59,92 @@ public:
     }
 
     auto cclAllReduceOp = rewriter.create<ccl::AllReduceOp>(
-        op->getLoc(), input, Value(), rewriter.getStringAttr(reduceOp),
+        op->getLoc(), input, Value(),
+        /*synchronous=*/rewriter.getBoolAttr(false),
+        rewriter.getStringAttr(reduceOp),
         rewriter.getArrayAttr(
             ArrayRef<Attribute>{rewriter.getI64ArrayAttr(ranks)}),
-        nullptr);
+        /*unique_id=*/nullptr);
     rewriter.replaceOp(op, cclAllReduceOp.getResult());
+    return success();
+  }
+};
+
+class ConvertC10dFunctionalAllGatherIntoTensorOp
+    : public OpConversionPattern<C10dFunctionalAllGatherIntoTensorOp> {
+public:
+  using OpConversionPattern<
+      C10dFunctionalAllGatherIntoTensorOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(C10dFunctionalAllGatherIntoTensorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value input = adaptor.getShard();
+    auto outType = getTypeConverter()->convertType(op.getResult().getType());
+
+    std::string tag;
+    if (!matchPattern(op.getTag(), m_TorchConstantStr(tag))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of tag");
+    }
+    llvm::SmallVector<int64_t> ranks;
+    if (!matchPattern(op.getRanks(), m_TorchListOfConstantInts(ranks))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of ranks");
+    }
+    int64_t groupSize;
+    if (!matchPattern(op.getGroupSize(), m_TorchConstantInt(&groupSize))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of group_size");
+    }
+
+    auto cclAllGatherOp = rewriter.create<ccl::AllGatherOp>(
+        op->getLoc(), outType, input, Value(),
+        /*synchronous=*/rewriter.getBoolAttr(false),
+        /*axis=*/rewriter.getI64IntegerAttr(0),
+        rewriter.getArrayAttr(
+            ArrayRef<Attribute>{rewriter.getI64ArrayAttr(ranks)}),
+        /*unique_id=*/nullptr);
+    rewriter.replaceOp(op, cclAllGatherOp.getResult());
+    return success();
+  }
+};
+
+class ConvertC10dFunctionalReduceScatterTensorOp
+    : public OpConversionPattern<C10dFunctionalReduceScatterTensorOp> {
+public:
+  using OpConversionPattern<
+      C10dFunctionalReduceScatterTensorOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(C10dFunctionalReduceScatterTensorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value input = adaptor.getInput();
+    auto outType = getTypeConverter()->convertType(op.getResult().getType());
+
+    std::string reduceOp, tag;
+    if (!matchPattern(op.getReduceOp(), m_TorchConstantStr(reduceOp))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of reduceOp");
+    }
+    if (!matchPattern(op.getTag(), m_TorchConstantStr(tag))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of tag");
+    }
+    llvm::SmallVector<int64_t> ranks;
+    if (!matchPattern(op.getRanks(), m_TorchListOfConstantInts(ranks))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of ranks");
+    }
+    int64_t groupSize;
+    if (!matchPattern(op.getGroupSize(), m_TorchConstantInt(&groupSize))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of group_size");
+    }
+
+    // TODO: handle "concat" mode or "stack" mode?
+    auto cclReduceScatterOp = rewriter.create<ccl::ReduceScatterOp>(
+        op->getLoc(), outType, input, Value(),
+        /*synchronous=*/rewriter.getBoolAttr(false),
+        rewriter.getStringAttr(reduceOp),
+        /*axis=*/rewriter.getI64IntegerAttr(0),
+        rewriter.getArrayAttr(
+            ArrayRef<Attribute>{rewriter.getI64ArrayAttr(ranks)}),
+        /*unique_id=*/nullptr);
+    rewriter.replaceOp(op, cclReduceScatterOp.getResult());
     return success();
   }
 };
@@ -77,12 +158,71 @@ public:
   matchAndRewrite(C10dFunctionalWaitTensorOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value input = adaptor.getSelf();
-    auto inputType = input.getType();
     auto outType = getTypeConverter()->convertType(op.getResult().getType());
 
     auto cclWaitTensorOp =
-        rewriter.create<ccl::WaitTensorOp>(op->getLoc(), outType, input);
+        rewriter.create<ccl::WaitOp>(op->getLoc(), outType, input);
     rewriter.replaceOp(op, cclWaitTensorOp.getResult());
+    return success();
+  }
+};
+
+class ConvertC10dFunctionalIsendOp
+    : public OpConversionPattern<C10dFunctionalIsendOp> {
+public:
+  using OpConversionPattern<C10dFunctionalIsendOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(C10dFunctionalIsendOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value input = adaptor.getSelf();
+    auto outType = getTypeConverter()->convertType(op.getResult().getType());
+
+    int64_t dst;
+    if (!matchPattern(op.getDst(), m_TorchConstantInt(&dst))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of dst");
+    }
+
+    auto cclSendOp = rewriter.create<ccl::SendOp>(
+        op->getLoc(), outType, input,
+        /*synchronous=*/rewriter.getBoolAttr(false),
+        /*target_index=*/rewriter.getI64IntegerAttr(dst));
+    rewriter.replaceOp(op, cclSendOp.getResult());
+    return success();
+  }
+};
+
+class ConvertC10dFunctionalIrecvOp
+    : public OpConversionPattern<C10dFunctionalIrecvOp> {
+public:
+  using OpConversionPattern<C10dFunctionalIrecvOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(C10dFunctionalIrecvOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value input = adaptor.getSelf();
+    auto outType = llvm::cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+
+    int64_t src;
+    if (!matchPattern(op.getSrc(), m_TorchConstantInt(&src))) {
+      return rewriter.notifyMatchFailure(op, "unsupported value of src");
+    }
+
+    if (outType.hasStaticShape()) {
+      auto cclRecvOp = rewriter.create<ccl::RecvOp>(
+          op->getLoc(), outType, Value(),
+          /*synchronous=*/rewriter.getBoolAttr(false),
+          /*target_index=*/rewriter.getI64IntegerAttr(src));
+      rewriter.replaceOp(op, cclRecvOp.getResult());
+    } else {
+      Value shape = rewriter.create<shape::ShapeOfOp>(op->getLoc(), input);
+      auto cclRecvOp = rewriter.create<ccl::RecvOp>(
+          op->getLoc(), outType, shape,
+          /*synchronous=*/rewriter.getBoolAttr(false),
+          /*target_index=*/rewriter.getI64IntegerAttr(src));
+      rewriter.replaceOp(op, cclRecvOp.getResult());
+    }
     return success();
   }
 };
@@ -111,6 +251,12 @@ public:
 
     target.addIllegalOp<C10dFunctionalAllReduceOp>();
     patterns.add<ConvertC10dFunctionalAllReduceOp>(typeConverter, context);
+    target.addIllegalOp<C10dFunctionalAllGatherIntoTensorOp>();
+    patterns.add<ConvertC10dFunctionalAllGatherIntoTensorOp>(typeConverter,
+                                                             context);
+    target.addIllegalOp<C10dFunctionalReduceScatterTensorOp>();
+    patterns.add<ConvertC10dFunctionalReduceScatterTensorOp>(typeConverter,
+                                                             context);
     target.addIllegalOp<C10dFunctionalWaitTensorOp>();
     patterns.add<ConvertC10dFunctionalWaitTensorOp>(typeConverter, context);
 

--- a/frontends/torch-frontend/torch-frontend/lib/Conversion/ConvertTorchToCcl.cpp
+++ b/frontends/torch-frontend/torch-frontend/lib/Conversion/ConvertTorchToCcl.cpp
@@ -235,13 +235,15 @@ public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<Torch::TorchDialect>();
     registry.insert<ccl::CclDialect>();
+    registry.insert<shape::ShapeDialect>();
     TorchConversion::getBackendTypeConversionDependentDialects(registry);
   }
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
-    target.addLegalDialect<Torch::TorchDialect, ccl::CclDialect>();
+    target.addLegalDialect<Torch::TorchDialect, ccl::CclDialect,
+                           shape::ShapeDialect>();
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
@@ -259,6 +261,10 @@ public:
                                                              context);
     target.addIllegalOp<C10dFunctionalWaitTensorOp>();
     patterns.add<ConvertC10dFunctionalWaitTensorOp>(typeConverter, context);
+    target.addIllegalOp<C10dFunctionalIsendOp>();
+    patterns.add<ConvertC10dFunctionalIsendOp>(typeConverter, context);
+    target.addIllegalOp<C10dFunctionalIrecvOp>();
+    patterns.add<ConvertC10dFunctionalIrecvOp>(typeConverter, context);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {

--- a/frontends/torch-frontend/torch-frontend/lib/Pipelines/Pipelines.cpp
+++ b/frontends/torch-frontend/torch-frontend/lib/Pipelines/Pipelines.cpp
@@ -28,6 +28,7 @@ using namespace mlir;
 using namespace mlir::torch;
 
 void mlir::torch_frontend::createTorchToMhloPipeline(OpPassManager &pm) {
+  pm.addNestedPass<func::FuncOp>(createConvertTorchToCcl());
   pm.addNestedPass<func::FuncOp>(createConvertTorchToCustomCall());
   pm.addNestedPass<func::FuncOp>(createConvertTorchToStablehloExt());
   pm.addNestedPass<func::FuncOp>(

--- a/frontends/torch-frontend/torch-frontend/python/CMakeLists.txt
+++ b/frontends/torch-frontend/torch-frontend/python/CMakeLists.txt
@@ -18,7 +18,7 @@ declare_mlir_python_sources(TorchFrontendPythonSources.TopLevel
     fx_rewrite.py
     fx_tracer.py
     fx_utils.py
-    convert_to_mhlo.py
+    compile.py
 )
 
 ################################################################################

--- a/frontends/torch-frontend/torch-frontend/python/test/test_ccl.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_ccl.py
@@ -1,0 +1,79 @@
+import torch
+import torch.multiprocessing as mp
+import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
+import os
+
+import torch_frontend
+from torch_frontend import compile_exported_program
+
+def setup(world_size, rank, port="4991", addr="localhost"):
+    os.environ["MASTER_ADDR"] = addr
+    os.environ["MASTER_PORT"] = port
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+def cleanup():
+    dist.barrier()
+    dist.destroy_process_group()
+
+def run(
+    rank,
+    world_size,
+    module,
+    inputs,
+    constraints=None,
+):
+    setup(world_size, rank)
+    prog = torch.export.export(module, tuple(inputs), constraints=constraints)
+    if rank == 0:
+        module = compile_exported_program(prog, "stablehlo")
+        print(module.operation.get_asm())
+    cleanup()
+
+# ==============================================================================
+
+class AllReduceModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    
+    def forward(self, x):
+        return funcol.all_reduce(x, "sum", [0, 1, 2, 3])
+
+def test_all_reduce():
+    module = AllReduceModule()
+    world_size = 4
+    inputs = [torch.tensor([1, 2, 3, 4], dtype=torch.float32)]
+    mp.spawn(run, args=(world_size, module, inputs), nprocs=world_size, join=True)
+
+# ==============================================================================
+
+class AllGatherModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    
+    def forward(self, x):
+        return funcol.all_gather_tensor(x, 0, [0, 1, 2, 3])
+
+def test_all_gather():
+    module = AllGatherModule()
+    world_size = 4
+    inputs = [torch.tensor([1, 2, 3, 4], dtype=torch.float32)]
+    mp.spawn(run, args=(world_size, module, inputs), nprocs=world_size, join=True)
+
+# ==============================================================================
+
+class ReduceScatterModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    
+    def forward(self, x):
+        return funcol.reduce_scatter_tensor(x, "sum", 0, [0, 1, 2, 3])
+
+def test_reduce_scatter():
+    module = ReduceScatterModule()
+    world_size = 4
+    inputs = [torch.tensor([1, 2, 3, 4], dtype=torch.float32)]
+    mp.spawn(run, args=(world_size, module, inputs), nprocs=world_size, join=True)
+
+# ==============================================================================
+# TODO: add test for send/recv

--- a/frontends/torch-frontend/torch-frontend/python/test/test_ccl.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_ccl.py
@@ -39,7 +39,7 @@ class AllReduceModule(torch.nn.Module):
     def forward(self, x):
         return funcol.all_reduce(x, "sum", [0, 1, 2, 3])
 
-def test_all_reduce():
+def all_reduce():
     module = AllReduceModule()
     world_size = 4
     inputs = [torch.tensor([1, 2, 3, 4], dtype=torch.float32)]
@@ -54,7 +54,7 @@ class AllGatherModule(torch.nn.Module):
     def forward(self, x):
         return funcol.all_gather_tensor(x, 0, [0, 1, 2, 3])
 
-def test_all_gather():
+def all_gather():
     module = AllGatherModule()
     world_size = 4
     inputs = [torch.tensor([1, 2, 3, 4], dtype=torch.float32)]
@@ -69,7 +69,7 @@ class ReduceScatterModule(torch.nn.Module):
     def forward(self, x):
         return funcol.reduce_scatter_tensor(x, "sum", 0, [0, 1, 2, 3])
 
-def test_reduce_scatter():
+def reduce_scatter():
     module = ReduceScatterModule()
     world_size = 4
     inputs = [torch.tensor([1, 2, 3, 4], dtype=torch.float32)]
@@ -77,3 +77,14 @@ def test_reduce_scatter():
 
 # ==============================================================================
 # TODO: add test for send/recv
+
+# ==============================================================================
+# TODO: fix mp with pytest
+
+# def test_all():
+#     all_reduce()
+#     all_gather()
+#     reduce_scatter()
+
+# if __name__ == "__main__":
+#     test_all()

--- a/frontends/torch-frontend/torch-frontend/python/torch_frontend/__init__.py
+++ b/frontends/torch-frontend/torch-frontend/python/torch_frontend/__init__.py
@@ -26,6 +26,6 @@ del importlib
 del _torch_frontend_registry
 
 from .fx_utils import list_decomposed_ops, preprocess_fx_graph, get_none_indices
-from .convert_to_mhlo import convert_to_mhlo_via_torch_mlir, compile, compile_exported_program
+from .compile import convert_to_mhlo_via_torch_mlir, compile, compile_exported_program
 from .flash_attn_op import replace_flash_attn
 from .fx_rewrite import fx_replace_attn_pattern

--- a/frontends/torch-frontend/torch-frontend/python/torch_frontend/compile.py
+++ b/frontends/torch-frontend/torch-frontend/python/torch_frontend/compile.py
@@ -7,6 +7,7 @@ from torch_frontend import torch_mlir
 from torch_mlir import ir
 from torch_mlir.passmanager import PassManager
 from torch_mlir.dialects import torch as torch_d
+from torch_mlir.extras.fx_importer import FxImporter
 
 _CUSTOM_OPS_IN_TORCH = [
     "aten._softmax",
@@ -149,7 +150,12 @@ def compile(
         pm.run(module.operation)
     return module
 
-
+"""
+    debug: int type, one of
+            `0: no debug message`,
+            `1: print after failure`,
+            `2: print after pass only on change`
+"""
 def compile_exported_program(
     model: torch.export.ExportedProgram,
     output_type: str,
@@ -163,7 +169,6 @@ def compile_exported_program(
     if backend_legal_ops is None:
         backend_legal_ops = _CUSTOM_OPS_IN_TORCH
 
-    from torch_mlir.extras.fx_importer import FxImporter
     context = ir.Context()
     torch_d.register_dialect(context)
     fx_importer = FxImporter(context=context)

--- a/frontends/torch-frontend/torch-frontend/test/Conversion/ConvertTorchToCcl.mlir
+++ b/frontends/torch-frontend/torch-frontend/test/Conversion/ConvertTorchToCcl.mlir
@@ -17,3 +17,90 @@ func.func @torch.c10d_functional.all_reduce(%arg0: !torch.vtensor<[4],f32>) -> (
 // CHECK: ccl.all_reduce
 // CHECK-SAME{LITERAL}: {reduction = "sum", replica_groups = [[0, 1, 2, 3]], synchronous = false}
 // CHECK: ccl.wait
+
+func.func @torch.c10d_functional.all_gather_into_tensor(%arg0: !torch.vtensor<[4],f32>) -> (!torch.vtensor<[16],f32>) {
+  %str_0 = torch.constant.str ""
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2, %int3 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %int4 = torch.constant.int 4
+  %1 = torch.c10d_functional.all_gather_into_tensor %arg0, %str_0, %0, %int4 : !torch.vtensor<[4],f32>, !torch.str, !torch.list<int>, !torch.int -> !torch.vtensor<[16],f32>
+  %2 = torch.c10d_functional.wait_tensor %1 : !torch.vtensor<[16],f32> -> !torch.vtensor<[16],f32>
+  return %2 : !torch.vtensor<[16],f32>
+}
+// CHECK-LABEL: func.func @torch.c10d_functional.all_gather_into_tensor
+// CHECK: ccl.all_gather
+// CHECK-SAME{LITERAL}: {axis = 0 : i64, replica_groups = [[0, 1, 2, 3]], synchronous = false}
+// CHECK: ccl.wait
+
+func.func @torch.c10d_functional.reduce_scatter_tensor(%arg0: !torch.vtensor<[4],f32>) -> (!torch.vtensor<[1],f32>) {
+  %str = torch.constant.str "sum"
+  %str_0 = torch.constant.str ""
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2, %int3 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %int4 = torch.constant.int 4
+  %1 = torch.c10d_functional.reduce_scatter_tensor %arg0, %str, %str_0, %0, %int4 : !torch.vtensor<[4],f32>, !torch.str, !torch.str, !torch.list<int>, !torch.int -> !torch.vtensor<[1],f32>
+  %2 = torch.c10d_functional.wait_tensor %1 : !torch.vtensor<[1],f32> -> !torch.vtensor<[1],f32>
+  return %2 : !torch.vtensor<[1],f32>
+}
+// CHECK-LABEL: func.func @torch.c10d_functional.reduce_scatter_tensor
+// CHECK: ccl.reduce_scatter
+// CHECK-SAME{LITERAL}: {axis = 0 : i64, reduction = "sum", replica_groups = [[0, 1, 2, 3]], synchronous = false}
+// CHECK: ccl.wait
+
+func.func @torch.c10d_functional.isend(%arg0: !torch.vtensor<[4],f32>) -> (!torch.vtensor<[4],f32>) {
+  %str_0 = torch.constant.str ""
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2, %int3 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %int4 = torch.constant.int 4
+  %1 = torch.c10d_functional.isend %arg0, %int1, %str_0, %0, %int4 : !torch.vtensor<[4],f32>, !torch.int, !torch.str, !torch.list<int>, !torch.int -> !torch.vtensor<[4],f32>
+  %2 = torch.c10d_functional.wait_tensor %1 : !torch.vtensor<[4],f32> -> !torch.vtensor<[4],f32>
+  return %2 : !torch.vtensor<[4],f32>
+}
+// CHECK-LABEL: func.func @torch.c10d_functional.isend
+// CHECK: ccl.send
+// CHECK-SAME{LITERAL}: {synchronous = false, target_index = 1 : i64}
+// CHECK: ccl.wait
+
+func.func @torch.c10d_functional.irecv(%arg0: !torch.vtensor<[4],f32>) -> (!torch.vtensor<[4],f32>) {
+  %str_0 = torch.constant.str ""
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2, %int3 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %int4 = torch.constant.int 4
+  %1 = torch.c10d_functional.irecv %arg0, %int0, %str_0, %0, %int4 : !torch.vtensor<[4],f32>, !torch.int, !torch.str, !torch.list<int>, !torch.int -> !torch.vtensor<[4],f32>
+  %2 = torch.c10d_functional.wait_tensor %1 : !torch.vtensor<[4],f32> -> !torch.vtensor<[4],f32>
+  return %2 : !torch.vtensor<[4],f32>
+}
+// CHECK-LABEL: func.func @torch.c10d_functional.irecv
+// CHECK: ccl.recv
+// CHECK-SAME{LITERAL}: {source_index = 0 : i64, synchronous = false}
+// CHECK: ccl.wait
+
+func.func @torch.c10d_functional.irecv.dynamic_shape(%arg0: !torch.vtensor<[?],f32>) -> (!torch.vtensor<[?],f32>) {
+  %str_0 = torch.constant.str ""
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2, %int3 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %int4 = torch.constant.int 4
+  %1 = torch.c10d_functional.irecv %arg0, %int0, %str_0, %0, %int4 : !torch.vtensor<[?],f32>, !torch.int, !torch.str, !torch.list<int>, !torch.int -> !torch.vtensor<[?],f32>
+  %2 = torch.c10d_functional.wait_tensor %1 : !torch.vtensor<[?],f32> -> !torch.vtensor<[?],f32>
+  return %2 : !torch.vtensor<[?],f32>
+}
+// CHECK-LABEL: func.func @torch.c10d_functional.irecv.dynamic_shape
+// CHECK: shape.shape_of
+// CHECK: ccl.recv
+// CHECK-SAME{LITERAL}: {source_index = 0 : i64, synchronous = false}
+// CHECK: ccl.wait

--- a/frontends/torch-frontend/torch-frontend/test/Conversion/ConvertTorchToCcl.mlir
+++ b/frontends/torch-frontend/torch-frontend/test/Conversion/ConvertTorchToCcl.mlir
@@ -15,5 +15,5 @@ func.func @torch.c10d_functional.all_reduce(%arg0: !torch.vtensor<[4],f32>) -> (
 }
 // CHECK-LABEL: func.func @torch.c10d_functional.all_reduce
 // CHECK: ccl.all_reduce
-// CHECK-SAME{LITERAL}: {reduction = "sum", replica_groups = [[0, 1, 2, 3]]}
-// CHECK: ccl.wait_tensor
+// CHECK-SAME{LITERAL}: {reduction = "sum", replica_groups = [[0, 1, 2, 3]], synchronous = false}
+// CHECK: ccl.wait


### PR DESCRIPTION
1. add `synchronous` attribute to all ccl dialect ops.
2. change `ccl.wait_tensor` to `ccl.wait`, because in future we may do bufferization on ccl dialect.
3. add definition of `ccl.send` and `ccl.recv`.
4. add all_gather and reduce_scatter's lowering to ccl dialect.
5. change filename `torch-frontend/convert_to_mhlo.py` to `torch-frontend/compile.py`.
6. add python test for ccl.