### PR TITLE
[compiler] fix set-arg-space on ViewLikeOp

### DIFF
--- a/compiler/lib/Analysis/SideEffect.cpp
+++ b/compiler/lib/Analysis/SideEffect.cpp
@@ -65,7 +65,12 @@ ArgSideEffectType ArgSideEffectAnalysis::getType(mlir::Operation *op,
             .has_value()) {
       return ArgSideEffectType::kInput;
     }
-    return ArgSideEffectType::kOutput;
+    if (opInter
+            .getEffectOnValue<MemoryEffects::Write>(op->getOperand(argOffset))
+            .has_value()) {
+      return ArgSideEffectType::kOutput;
+    }
+    return ArgSideEffectType::kError;
   }
 
   // if no MemoryEffectOpInterface, use lookup


### PR DESCRIPTION
* allow ViewLikeOp have memory space attribute, and ensure that ViewLikeOp's memory space is same as space attribute.