### PR TITLE
[compiler] use stablehlo & chlo's python binding

### DIFF
--- a/compiler/cmake/CMakeLists.txt
+++ b/compiler/cmake/CMakeLists.txt
@@ -119,7 +119,7 @@ add_subdirectory(${BYTEIR_SRC_DIR}/tools ${BYTEIR_BINARY_DIR}/tools)
 if (BYTEIR_ENABLE_BINDINGS_PYTHON)
   include(MLIRDetectPythonEnv)
   mlir_configure_python_dev_packages()
-  add_subdirectory(${BYTEIR_SRC_DIR}/python ${CMAKE_BINARY_DIR}/python)
+  add_subdirectory(${BYTEIR_SRC_DIR}/python ${BYTEIR_BINARY_DIR}/python)
 endif()
 
 if(MSVC)

--- a/compiler/cmake/mhlo.cmake
+++ b/compiler/cmake/mhlo.cmake
@@ -1,13 +1,7 @@
 add_subdirectory(${BYTEIR_SRC_DIR}/../external/mlir-hlo ${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo EXCLUDE_FROM_ALL)
 
-# FIXME: remove this when upstream fix
-target_link_libraries(MhloDialect PUBLIC StablehloTypeInference StablehloAssemblyFormat)
-target_link_libraries(MLIRBufferTransforms PUBLIC DeallocationPasses)
-
 include_directories(${BYTEIR_SRC_DIR}/../external/mlir-hlo)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo)
-include_directories(${BYTEIR_SRC_DIR}/../external/mlir-hlo/include)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo/include)
 include_directories(${BYTEIR_SRC_DIR}/../external/mlir-hlo/stablehlo)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo/stablehlo)
 

--- a/compiler/include/byteir-c/Dialects.h
+++ b/compiler/include/byteir-c/Dialects.h
@@ -25,6 +25,8 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Cat, cat);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Ace, ace);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Ccl, ccl);
 
 MLIR_CAPI_EXPORTED void byteirRegisterDialectExtensions(MlirContext context);
 

--- a/compiler/lib/CAPI/Dialects.cpp
+++ b/compiler/lib/CAPI/Dialects.cpp
@@ -17,7 +17,9 @@
 
 #include "byteir-c/Dialects.h"
 
+#include "byteir/Dialect/Ace/AceDialect.h"
 #include "byteir/Dialect/Cat/IR/CatDialect.h"
+#include "byteir/Dialect/Ccl/IR/CclOps.h"
 #include "byteir/Dialect/Ccl/TransformOps/CclTransformOps.h"
 #include "byteir/Dialect/Linalg/TransformOps/LinalgExtTransformOps.h"
 #include "byteir/Dialect/Tensor/IR/TilingInterfaceImpl.h"
@@ -28,6 +30,8 @@
 using namespace mlir;
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Cat, cat, mlir::cat::CatDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Ace, ace, mlir::ace::AceDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Ccl, ccl, mlir::ccl::CclDialect)
 
 void byteirRegisterDialectExtensions(MlirContext context) {
   DialectRegistry registry;

--- a/compiler/python/ByteIRModules.cpp
+++ b/compiler/python/ByteIRModules.cpp
@@ -22,8 +22,6 @@
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
-#include "stablehlo/integrations/c/ChloDialect.h"
-#include "stablehlo/integrations/c/StablehloDialect.h"
 
 namespace py = pybind11;
 
@@ -41,28 +39,6 @@ PYBIND11_MODULE(_byteir, m) {
       "register_cat_dialect",
       [](MlirContext context, bool load) {
         MlirDialectHandle handle = mlirGetDialectHandle__cat__();
-        mlirDialectHandleRegisterDialect(handle, context);
-        if (load) {
-          mlirDialectHandleLoadDialect(handle, context);
-        }
-      },
-      py::arg("context"), py::arg("load") = true);
-
-  m.def(
-      "register_stablehlo_dialect",
-      [](MlirContext context, bool load) {
-        MlirDialectHandle handle = mlirGetDialectHandle__stablehlo__();
-        mlirDialectHandleRegisterDialect(handle, context);
-        if (load) {
-          mlirDialectHandleLoadDialect(handle, context);
-        }
-      },
-      py::arg("context"), py::arg("load") = true);
-
-  m.def(
-      "register_chlo_dialect",
-      [](MlirContext context, bool load) {
-        MlirDialectHandle handle = mlirGetDialectHandle__chlo__();
         mlirDialectHandleRegisterDialect(handle, context);
         if (load) {
           mlirDialectHandleLoadDialect(handle, context);

--- a/compiler/python/ByteIRModules.cpp
+++ b/compiler/python/ByteIRModules.cpp
@@ -45,6 +45,26 @@ PYBIND11_MODULE(_byteir, m) {
         }
       },
       py::arg("context"), py::arg("load") = true);
+  m.def(
+      "register_ace_dialect",
+      [](MlirContext context, bool load) {
+        MlirDialectHandle handle = mlirGetDialectHandle__ace__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (load) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context"), py::arg("load") = true);
+  m.def(
+      "register_ccl_dialect",
+      [](MlirContext context, bool load) {
+        MlirDialectHandle handle = mlirGetDialectHandle__ccl__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (load) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context"), py::arg("load") = true);
 
   m.def("register_dialect_extensions", &byteirRegisterDialectExtensions,
         py::arg("context"));

--- a/compiler/python/CMakeLists.txt
+++ b/compiler/python/CMakeLists.txt
@@ -54,8 +54,6 @@ declare_mlir_python_extension(ByteIRPythonExtensions.Main
     ByteIRModules.cpp
   EMBED_CAPI_LINK_LIBS
     ByteIRCAPI
-    StablehloCAPI
-    ChloCAPI
   PRIVATE_LINK_LIBS
     LLVMSupport
 )
@@ -74,6 +72,10 @@ add_mlir_python_common_capi_library(ByteIRCAPIAggregation
     MLIRPythonExtension.RegisterEverything
     MLIRHLOPythonSources
     MLIRHLOPythonExtensions
+    ChloPythonSources
+    ChloPythonExtensions
+    StablehloPythonSources
+    StablehloPythonExtensions
     ByteIRPythonSources
     ByteIRPythonExtensions
 )
@@ -94,6 +96,10 @@ add_mlir_python_modules(ByteIRPythonModules
     MLIRPythonExtension.RegisterEverything
     MLIRHLOPythonSources
     MLIRHLOPythonExtensions
+    ChloPythonSources
+    ChloPythonExtensions
+    StablehloPythonSources
+    StablehloPythonExtensions
     ByteIRPythonSources
     ByteIRPythonExtensions
   COMMON_CAPI_LINK_LIBS

--- a/compiler/python/byteir/_mlir_libs/_site_initialize_0.py
+++ b/compiler/python/byteir/_mlir_libs/_site_initialize_0.py
@@ -1,13 +1,14 @@
 def context_init_hook(context):
     from ._byteir import register_dialect_extensions, register_cat_dialect, register_translation_dialects
-    from ._byteir import register_stablehlo_dialect, register_chlo_dialect
     from ._mlirHlo import register_mhlo_dialect
+    from ._stablehlo import register_dialect as register_stablehlo_dialect
+    from ._chlo import register_dialect as register_chlo_dialect
 
     register_stablehlo_dialect(context)
     register_chlo_dialect(context)
+    register_mhlo_dialect(context)
     register_cat_dialect(context)
     register_dialect_extensions(context)
-    register_mhlo_dialect(context)
     register_translation_dialects(context)
 
     context.allow_unregistered_dialects = True

--- a/compiler/python/byteir/_mlir_libs/_site_initialize_0.py
+++ b/compiler/python/byteir/_mlir_libs/_site_initialize_0.py
@@ -1,5 +1,6 @@
 def context_init_hook(context):
-    from ._byteir import register_dialect_extensions, register_cat_dialect, register_translation_dialects
+    from ._byteir import register_cat_dialect, register_ace_dialect, register_ccl_dialect
+    from ._byteir import register_dialect_extensions, register_translation_dialects
     from ._mlirHlo import register_mhlo_dialect
     from ._stablehlo import register_dialect as register_stablehlo_dialect
     from ._chlo import register_dialect as register_chlo_dialect
@@ -8,6 +9,8 @@ def context_init_hook(context):
     register_chlo_dialect(context)
     register_mhlo_dialect(context)
     register_cat_dialect(context)
+    register_ace_dialect(context)
+    register_ccl_dialect(context)
     register_dialect_extensions(context)
     register_translation_dialects(context)
 


### PR DESCRIPTION
1. fix cmake.
2. use stablehlo & chlo's python binding, instead of register them in ByteIRModules.
3. add register_ace_dialect and register_ccl_dialect.