### PR TITLE
[runtime] register __truncdfhf2 in jit

### DIFF
--- a/runtime/lib/backends/cpu/device/llvm/jit.cc
+++ b/runtime/lib/backends/cpu/device/llvm/jit.cc
@@ -273,6 +273,11 @@ extern "C" void memrefCopy(int64_t elemSize,
   }
 }
 
+extern "C" uint16_t __truncdfhf2(double v) {
+  return _cvtss_sh(static_cast<float>(v),
+                   _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+}
+
 void InitJITKernelRTSymbols(LLVMJIT *jit) {
 #define REG2(name, symbol)                                                     \
   if (!jit->Lookup(name, nullptr).IsOK()) {                                    \
@@ -282,6 +287,7 @@ void InitJITKernelRTSymbols(LLVMJIT *jit) {
 #define REG(symbol) REG2(#symbol, symbol)
 
   REG(memrefCopy);
+  REG(__truncdfhf2);
   // TODO: replace with the call of session host allocator's corresponding
   // method
   REG2("malloc", ::malloc);


### PR DESCRIPTION
* to support cast from `f64` to `f16` on cpu.