### PR TITLE
[compiler] change capi from MlirOperation to MlirModule

### DIFF
--- a/compiler/include/byteir-c/Translation.h
+++ b/compiler/include/byteir-c/Translation.h
@@ -27,11 +27,11 @@ extern "C" {
 
 MLIR_CAPI_EXPORTED void byteirRegisterTranslationDialects(MlirContext context);
 
-MLIR_CAPI_EXPORTED void byteirTranslateToPTX(MlirOperation op,
+MLIR_CAPI_EXPORTED void byteirTranslateToPTX(MlirModule module,
                                              MlirStringRef ptxFilePrefixName,
                                              MlirStringRef gpuArch);
 
-MLIR_CAPI_EXPORTED bool byteirTranslateToLLVMBC(MlirOperation op,
+MLIR_CAPI_EXPORTED bool byteirTranslateToLLVMBC(MlirModule module,
                                                 MlirStringRef outputFile);
 
 #ifdef __cplusplus

--- a/compiler/include/byteir/Target/PTX/ToPTX.h
+++ b/compiler/include/byteir/Target/PTX/ToPTX.h
@@ -19,6 +19,7 @@
 #define BYTEIR_TARGET_PTX_TOPTX_H
 
 #include "byteir/Target/Common/Common.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/ScopedHashTable.h"
@@ -30,7 +31,8 @@ namespace mlir {
 
 void registerToPTXTranslation();
 
-LogicalResult translateToPTX(Operation *op, const std::string &prefix = "out",
+LogicalResult translateToPTX(mlir::ModuleOp module,
+                             const std::string &prefix = "out",
                              OptLevel level = OptLevel::O3,
                              const std::string &gpuArch = "sm_70",
                              bool dumpPtx = false, bool saveTemp = false,

--- a/compiler/lib/CAPI/Translation.cpp
+++ b/compiler/lib/CAPI/Translation.cpp
@@ -44,15 +44,16 @@ void byteirRegisterTranslationDialects(MlirContext context) {
   unwrap(context)->appendDialectRegistry(registry);
 }
 
-void byteirTranslateToPTX(MlirOperation op, MlirStringRef ptxFilePrefixName,
+void byteirTranslateToPTX(MlirModule op, MlirStringRef ptxFilePrefixName,
                           MlirStringRef gpuArch) {
   (void)translateToPTX(unwrap(op), std::string(unwrap(ptxFilePrefixName)),
                        OptLevel::O3, std::string(unwrap(gpuArch)));
 }
 
-bool byteirTranslateToLLVMBC(MlirOperation op, MlirStringRef outputFile) {
+bool byteirTranslateToLLVMBC(MlirModule op, MlirStringRef outputFile) {
   llvm::LLVMContext llvmContext;
-  auto llvmModule = mlir::translateModuleToLLVMIR(unwrap(op), llvmContext);
+  auto llvmModule =
+      mlir::translateModuleToLLVMIR(unwrap(op).getOperation(), llvmContext);
   if (!llvmModule) {
     return false;
   }

--- a/compiler/lib/Target/PTX/TranslateToPTX.cpp
+++ b/compiler/lib/Target/PTX/TranslateToPTX.cpp
@@ -244,13 +244,10 @@ struct ptxGenerator {
 
 } // namespace
 
-LogicalResult mlir::translateToPTX(Operation *op, const std::string &prefix,
-                                   OptLevel level, const std::string &gpuArch,
-                                   bool dumpPtx, bool saveTemp, bool verbose) {
-  // only take module
-  auto m = dyn_cast<ModuleOp>(op);
-  if (!m)
-    return failure();
+LogicalResult mlir::translateToPTX(mlir::ModuleOp module,
+                                   const std::string &prefix, OptLevel level,
+                                   const std::string &gpuArch, bool dumpPtx,
+                                   bool saveTemp, bool verbose) {
   ptxGenerator ptxGen(prefix, level, gpuArch, dumpPtx, saveTemp, verbose);
-  return ptxGen.emitOperation(m);
+  return ptxGen.emitOperation(module);
 }

--- a/compiler/python/ByteIRModules.cpp
+++ b/compiler/python/ByteIRModules.cpp
@@ -98,7 +98,7 @@ PYBIND11_MODULE(_byteir, m) {
 
   m.def(
       "translate_to_ptx",
-      [](MlirOperation module, const std::string &ptx_prefix_file_name,
+      [](MlirModule module, const std::string &ptx_prefix_file_name,
          const std::string &gpu_arch) {
         byteirTranslateToPTX(module, toMlirStringRef(ptx_prefix_file_name),
                              toMlirStringRef(gpu_arch));
@@ -107,7 +107,7 @@ PYBIND11_MODULE(_byteir, m) {
       py::arg("gpu_arch") = "sm_70");
   m.def(
       "translate_to_llvmbc",
-      [](MlirOperation module, const std::string &outputFile) -> bool {
+      [](MlirModule module, const std::string &outputFile) -> bool {
         return byteirTranslateToLLVMBC(module, toMlirStringRef(outputFile));
       },
       py::arg("module"), py::arg("output_file"));

--- a/compiler/python/byteir/compile.py
+++ b/compiler/python/byteir/compile.py
@@ -78,7 +78,7 @@ def compile_cuda(
             PassManager.parse("builtin.module(nvvm-codegen)").run(device_module.operation)
         _print_verbose(device_module, "// IR Dump After NVVM Codegen:") if verbose else ...
     # write to output device ptx file
-    byteir.translate_to_ptx(device_module.operation, output_file_dir + "/" + output_file_name)
+    byteir.translate_to_ptx(device_module, output_file_dir + "/" + output_file_name)
 
     # create host mlir
     with context:
@@ -183,7 +183,7 @@ def compile_cuda_with_ait(
         _print_verbose(device_module, "// IR Dump After NVVM Codegen:") if verbose else ...
     # write to output device ptx
     assert detect_cuda_with_nvidia_smi() != None
-    byteir.translate_to_ptx(device_module.operation, output_file_dir + "/" + output_file_name, detect_cuda_with_nvidia_smi())
+    byteir.translate_to_ptx(device_module, output_file_dir + "/" + output_file_name, detect_cuda_with_nvidia_smi())
 
     with context:
         PassManager.parse("builtin.module(byre-host{device-file-name=" + output_file_name + ".ptx" + " " + target_str + " " + entry_func_str + "})").run(processor.module.operation)


### PR DESCRIPTION
* `MlirModule` is more strict than `MlirOperation`.