### PR TITLE
[torch-frontend] refactor building method when involving torch-mlir

### DIFF
--- a/frontends/torch-frontend/CMakeLists.txt
+++ b/frontends/torch-frontend/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TORCH_FRONTEND_BIN_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_CXX_STANDARD 17)
 
 include(MLIR.cmake)
+include(TorchMLIR.cmake)
 
 #-------------------------------------------------------------------------------
 # Third Parties
@@ -19,8 +20,9 @@ include(MLIR.cmake)
 set(TORCH_MLIR_BUILD_EMBEDDED ON)
 set(TORCH_MLIR_ENABLE_STABLEHLO ON)
 add_definitions(-DTORCH_MLIR_ENABLE_STABLEHLO)
-set(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER ON)
-set(TORCH_MLIR_ENABLE_LTC OFF)
+set(STABLEHLO_ENABLE_BINDINGS_PYTHON ON)
+set(TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS OFF)
+
 add_subdirectory(third_party/torch-mlir ${TORCH_FRONTEND_BIN_ROOT}/torch-mlir EXCLUDE_FROM_ALL)
 # add torch-mlir header files
 include_directories(${TORCH_FRONTEND_SRC_ROOT}/third_party/torch-mlir/include)

--- a/frontends/torch-frontend/TorchMLIR.cmake
+++ b/frontends/torch-frontend/TorchMLIR.cmake
@@ -1,0 +1,50 @@
+#-------------------------------------------------------------------------------
+# Build Torch-MLIR
+#-------------------------------------------------------------------------------
+
+message(STATUS "Build Torch-MLIR with MLIR: ${MLIR_DIR}")
+message(STATUS "Build Torch-MLIR with LLVM: ${LLVM_DIR}")
+
+function(build_torch_mlir)
+  set(TORCH_MLIR_SRC_PATH "${TORCH_FRONTEND_SRC_ROOT}/third_party/torch-mlir")
+  set(TORCH_MLIR_BUILD_PATH "${TORCH_FRONTEND_BIN_ROOT}/torch_mlir_build")
+  execute_process(COMMAND ${CMAKE_COMMAND}
+    -S "${TORCH_MLIR_SRC_PATH}"
+    -B "${TORCH_MLIR_BUILD_PATH}"
+    -G "${CMAKE_GENERATOR}"
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_BUILD_TYPE=Release
+    -DLLVM_DIR=${LLVM_DIR}
+    -DMLIR_DIR=${MLIR_DIR}
+    -DMLIR_ENABLE_BINDINGS_PYTHON=ON
+    -DLLVM_ENABLE_ZSTD=OFF
+    -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON
+    -DCMAKE_C_VISIBILITY_PRESET=hidden
+    -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+    -DTORCH_MLIR_ENABLE_LTC=OFF
+    -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON
+    -DCMAKE_CXX_FLAGS="-Wno-unused-but-set-parameter -Wno-unused-but-set-variable"
+    -DPython3_EXECUTABLE="$(which python3)"
+    -DLLVM_EXTERNAL_LIT="$(which lit)"
+
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${TORCH_MLIR_SRC_PATH}
+  )
+
+  if(result)
+    message(FATAL_ERROR "CMake step for torch-mlir failed: ${result}")
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} --build ${TORCH_MLIR_BUILD_PATH} --target TorchMLIRPythonModules
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${TORCH_MLIR_SRC_PATH}
+  )
+
+  if(result)
+    message(FATAL_ERROR "Build step for torch-mlir failed: ${result}")
+  endif()
+endfunction(build_torch_mlir)
+
+build_torch_mlir()

--- a/frontends/torch-frontend/TorchMLIR.cmake
+++ b/frontends/torch-frontend/TorchMLIR.cmake
@@ -24,9 +24,9 @@ function(build_torch_mlir)
     -DCMAKE_CXX_VISIBILITY_PRESET=hidden
     -DTORCH_MLIR_ENABLE_LTC=OFF
     -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON
-    -DCMAKE_CXX_FLAGS="-Wno-unused-but-set-parameter -Wno-unused-but-set-variable"
-    -DPython3_EXECUTABLE="$(which python3)"
-    -DLLVM_EXTERNAL_LIT="$(which lit)"
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+    -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
+    -DLLVM_EXTERNAL_LIT=${LLVM_EXTERNAL_LIT}
 
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${TORCH_MLIR_SRC_PATH}

--- a/frontends/torch-frontend/scripts/build_and_test.sh
+++ b/frontends/torch-frontend/scripts/build_and_test.sh
@@ -28,6 +28,6 @@ cmake -S . \
 
 cmake --build ./build --target all
 
-PYTHONPATH=./build/python_packages/ python3 -m pytest torch-frontend/python/test
+PYTHONPATH=build/python_packages/:build/torch_mlir_build/python_packages/torch_mlir python3 -m pytest torch-frontend/python/test
 
 popd

--- a/frontends/torch-frontend/torch-frontend/python/CMakeLists.txt
+++ b/frontends/torch-frontend/torch-frontend/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(AddMLIRPython)
 
-add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=torch_mlir.")
+add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=torch_frontend.")
 
 ################################################################################
 # Python sources
@@ -11,8 +11,8 @@ declare_mlir_python_sources(TorchFrontendPythonSources.TopLevel
   ADD_TO_PARENT TorchFrontendPythonSources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/torch_frontend"
   SOURCES
+    _mlir_libs/_site_initialize_0.py
     __init__.py
-    _torch_frontend_registry.py
     ts_utils.py
     flash_attn_op.py
     fx_rewrite.py
@@ -47,65 +47,29 @@ set(_source_components
   MLIRPythonSources
   MLIRPythonExtension.Core
   MLIRPythonExtension.RegisterEverything
-  TorchMLIRPythonSources
   TorchMLIRPythonExtensions
-  TorchFrontendMLIRPythonExtensions
+  StablehloPythonExtensions
 
-  # Sources related to optional Torch extension dependent features. Typically
-  # empty unless if project features are enabled.
-  TorchMLIRPythonTorchExtensionsSources
+  TorchFrontendPythonSources
+  TorchFrontendMLIRPythonExtensions
 )
 
 add_mlir_python_common_capi_library(TorchFrontendMLIRAggregateCAPI
-  INSTALL_COMPONENT TorchFrontendMLIRPythonModules
-  INSTALL_DESTINATION python_packages/torch_frontend/torch_mlir/_mlir_libs
-  OUTPUT_DIRECTORY "${TORCH_FRONTEND_BINARY_DIR}/python_packages/torch_frontend/torch_mlir/_mlir_libs"
-  RELATIVE_INSTALL_ROOT "../../../.."
+  INSTALL_COMPONENT TorchFrontendPythonModules
+  INSTALL_DESTINATION python_packages/torch_frontend/_mlir_libs
+  OUTPUT_DIRECTORY "${TORCH_FRONTEND_BINARY_DIR}/python_packages/torch_frontend/_mlir_libs"
+  RELATIVE_INSTALL_ROOT "../../.."
   DECLARED_SOURCES ${_source_components}
 )
 
 target_link_options(TorchFrontendMLIRAggregateCAPI PRIVATE $<$<PLATFORM_ID:Linux>:LINKER:--exclude-libs,ALL>)
 
-add_mlir_python_modules(TorchFrontendMLIRPythonModules
-  ROOT_PREFIX "${TORCH_FRONTEND_BINARY_DIR}/python_packages/torch_frontend/torch_mlir"
-  INSTALL_PREFIX "python_packages/torch_frontend/torch_mlir"
-  DECLARED_SOURCES ${_source_components}
-  COMMON_CAPI_LINK_LIBS TorchFrontendMLIRAggregateCAPI
-)
-
-# change output dir of _jit_ir_importer
-set_target_properties(TorchMLIRJITIRImporterPybind PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${TORCH_FRONTEND_BINARY_DIR}/python_packages/torch_frontend/torch_mlir/_mlir_libs"
-)
-
-# manually link against TorchFrontendMLIRAggregateCAPI instead of TorchMLIRAggregateCAPI
-function(patch_linked_library)
-  foreach(target ${ARGN})
-    get_target_property(LIBS ${target} LINK_LIBRARIES)
-    if (TorchMLIRAggregateCAPI IN_LIST LIBS)
-      list(REMOVE_ITEM LIBS TorchMLIRAggregateCAPI)
-      list(APPEND LIBS TorchFrontendMLIRAggregateCAPI)
-      set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${LIBS}")
-    endif()
-
-    get_target_property(LIBS ${target} INTERFACE_LINK_LIBRARIES)
-    if (TorchMLIRAggregateCAPI IN_LIST LIBS)
-      list(REMOVE_ITEM LIBS TorchMLIRAggregateCAPI)
-      list(APPEND LIBS TorchFrontendMLIRAggregateCAPI)
-      set_target_properties(${target} PROPERTIES INTERFACE_LINK_LIBRARIES "${LIBS}")
-    endif()
-  endforeach()
-endfunction()
-patch_linked_library(TorchMLIRJITIRImporter)
-
 add_mlir_python_modules(TorchFrontendPythonModules
   ROOT_PREFIX "${TORCH_FRONTEND_BINARY_DIR}/python_packages/torch_frontend"
   INSTALL_PREFIX "python_packages/torch_frontend"
-  DECLARED_SOURCES TorchFrontendPythonSources
+  DECLARED_SOURCES ${_source_components}
+  COMMON_CAPI_LINK_LIBS TorchFrontendMLIRAggregateCAPI
 )
-
-add_dependencies(TorchFrontendPythonModules TorchFrontendMLIRPythonModules)
-add_dependencies(TorchFrontendPythonModules TorchMLIRJITIRImporterPybind)
 
 ################################################################################
 # Build Python Wheel

--- a/frontends/torch-frontend/torch-frontend/python/setup.py
+++ b/frontends/torch-frontend/torch-frontend/python/setup.py
@@ -86,7 +86,7 @@ setup(
     name=name,
     packages=["torch_frontend", "torch_mlir"],
     package_data={"torch_mlir": ["extras/*.py"]},
-    package_dir={"torch_frontend": setup_path+" /torch_frontend", "torch_mlir": root_path+"/third_party/torch-mlir/python/torch_mlir"},
+    package_dir={"torch_frontend": setup_path+"/torch_frontend", "torch_mlir": root_path+"/third_party/torch-mlir/python/torch_mlir"},
     include_package_data=False,
     ext_modules=[TorchFrontendExtension("torch_frontend")],
     cmdclass={

--- a/frontends/torch-frontend/torch-frontend/python/torch_frontend/__init__.py
+++ b/frontends/torch-frontend/torch-frontend/python/torch_frontend/__init__.py
@@ -1,27 +1,4 @@
-import sys
-import importlib.util
-
-try:
-    import torch_mlir
-except ImportError:
-    torch_mlir_module_spec = importlib.util.find_spec(__name__ + ".torch_mlir")
-    torch_mlir_module = importlib.util.module_from_spec(torch_mlir_module_spec)
-    sys.modules["torch_mlir"] = torch_mlir_module
-    torch_mlir_module_spec.loader.exec_module(torch_mlir_module)
-    del torch_mlir_module_spec
-    del torch_mlir_module
-except Exception:
-    raise
-else:
-    # FIXME: handle reimport
-    raise ImportError("Found already installed or imported torch_mlir which might has conflicted with torch_frontend")
-
-
-from ._torch_frontend_registry import *
-
-del sys
-del importlib
-del _torch_frontend_registry
+from ._mlir_libs._torchFrontend import *
 
 from .fx_utils import list_decomposed_ops, preprocess_fx_graph, get_none_indices
 from .compile import convert_to_mhlo_via_torch_mlir, compile, compile_dynamo_model

--- a/frontends/torch-frontend/torch-frontend/python/torch_frontend/_mlir_libs/_site_initialize_0.py
+++ b/frontends/torch-frontend/torch-frontend/python/torch_frontend/_mlir_libs/_site_initialize_0.py
@@ -1,0 +1,6 @@
+def context_init_hook(context):
+    from ._stablehlo import register_dialect as register_stablehlo_dialect
+    from ._torchMlir import register_dialect as register_torch_dialect
+
+    register_stablehlo_dialect(context)
+    register_torch_dialect(context)

--- a/frontends/torch-frontend/torch-frontend/python/torch_frontend/_torch_frontend_registry.py
+++ b/frontends/torch-frontend/torch-frontend/python/torch_frontend/_torch_frontend_registry.py
@@ -1,1 +1,0 @@
-from torch_mlir._mlir_libs._torchFrontend import *


### PR DESCRIPTION
* split `torch_mlir` from `torch_frontend`, change `torch_frontend.torch_mlir` to `torch_frontend;torch_mlir`