### PR TITLE
[torch-frontend] support build without jit_ir_importer

### DIFF
--- a/frontends/torch-frontend/scripts/build_and_test.sh
+++ b/frontends/torch-frontend/scripts/build_and_test.sh
@@ -3,6 +3,21 @@
 set -e
 set -x
 
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --disable-jit-ir)
+      TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER=ON
+      shift
+      ;;
+    *)
+      echo "Invalid option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER=${TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER:-OFF}
+
 # path to script
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # path to byteir root
@@ -22,6 +37,7 @@ cmake -S . \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_C_COMPILER=gcc \
       -DCMAKE_CXX_COMPILER=g++ \
+      -DTORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER=${TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER} \
       -DCMAKE_CXX_FLAGS="-Wno-unused-but-set-parameter -Wno-unused-but-set-variable" \
       -DPython3_EXECUTABLE=$(which python3)
 

--- a/frontends/torch-frontend/torch-frontend/python/CMakeLists.txt
+++ b/frontends/torch-frontend/torch-frontend/python/CMakeLists.txt
@@ -77,6 +77,6 @@ add_mlir_python_modules(TorchFrontendPythonModules
 
 add_custom_target(
   torch_frontend_python_pack
-  COMMAND ${Python3_EXECUTABLE} "${TORCH_FRONTEND_SRC_ROOT}/torch-frontend/python/setup.py" "bdist_wheel"
+  COMMAND TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER=${TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER} ${Python3_EXECUTABLE} "${TORCH_FRONTEND_SRC_ROOT}/torch-frontend/python/setup.py" "bdist_wheel"
   DEPENDS TorchFrontendPythonModules
 )

--- a/frontends/torch-frontend/torch-frontend/python/setup.py
+++ b/frontends/torch-frontend/torch-frontend/python/setup.py
@@ -6,6 +6,9 @@ import os
 import shutil
 import subprocess
 
+def check_env_flag(name: str, default=None) -> bool:
+    return str(os.getenv(name, default)).upper() in ["ON", "1", "YES", "TRUE", "Y"]
+
 def get_git_commit(src_dir):
     try:
         return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=src_dir).decode('ascii').strip()
@@ -30,12 +33,14 @@ def get_torch_frontend_version_and_generate_versoin_file(input_version_txt_path,
 
     return torch_frontend_ver
 
+TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER = check_env_flag("TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER", False)
+
 setup_path = os.path.abspath(os.path.dirname(__file__))
 root_path = os.path.abspath(setup_path + "/../../")
 
 version_txt = os.path.join(setup_path, "version.txt")
 version_file = os.path.join(setup_path, "torch_frontend", "version.py")
-version = get_torch_frontend_version_and_generate_versoin_file(version_txt, version_file, root_path, dev=False)
+version = get_torch_frontend_version_and_generate_versoin_file(version_txt, version_file, root_path, dev=TORCH_FRONTEND_DISABLE_JIT_IR_IMPORTER)
 
 maintainer = "ByteIR Team"
 maintainer_email = "byteir@bytedance.com"


### PR DESCRIPTION
disable jit_ir_importer will make torch-frontend get rid of dependency on specific torch version.