### PR TITLE
[torch-frontend] update torch-mlir

### DIFF
--- a/frontends/torch-frontend/scripts/envsetup.sh
+++ b/frontends/torch-frontend/scripts/envsetup.sh
@@ -13,7 +13,7 @@ PROJ_DIR="$ROOT_PROJ_DIR/frontends/torch-frontend"
 TORCH_MLIR_ROOT="$PROJ_DIR/third_party/torch-mlir"
 
 function load_pytorch_llvm_prebuilt() {
-  TORCH_FRONTEND_LLVM_INSTALL_DIR="/data00/llvm_libraries/e5ed7b6e2fd368b722b6359556cd0125881e7638/llvm_build"
+  TORCH_FRONTEND_LLVM_INSTALL_DIR="/data00/llvm_libraries/0030fc4ac74a9ce645adb9d59e108da4d4d11818/llvm_build"
 }
 
 function apply_patches() {

--- a/frontends/torch-frontend/third_party/patches/fx_list_return.patch
+++ b/frontends/torch-frontend/third_party/patches/fx_list_return.patch
@@ -1,14 +1,8 @@
-commit 7316feb017ed93195f6239cb70216429da114cbb
-Author: wujiawei.aml <wujiawei.aml@bytedance.com>
-Date:   Sat Mar 16 18:09:38 2024 +0800
-
-    [FxImporter]: support parsing nodes which return list
-
 diff --git a/python/torch_mlir/extras/fx_importer.py b/python/torch_mlir/extras/fx_importer.py
-index 4eaeb7ac..dac0f755 100644
+index aee8251b..d157225a 100644
 --- a/python/torch_mlir/extras/fx_importer.py
 +++ b/python/torch_mlir/extras/fx_importer.py
-@@ -888,6 +888,20 @@ class ContextCache:
+@@ -927,6 +927,19 @@ class ContextCache:
              tensor_meta = node.meta.get("tensor_meta")
              val = node.meta.get("val")
              sparsity = node.meta.get("sparsity", None)
@@ -25,11 +19,10 @@ index 4eaeb7ac..dac0f755 100644
 +                        f"FIXME: Unsupported placeholder node (this often indicates that a necessary) "
 +                        f"fx preprocessing pass was not run): {node.meta}"
 +                    )
-+
-             if tensor_meta is not None:
-                 assert isinstance(tensor_meta, TensorMetadata)
-                 # Quantized tensor meta data is not preserved in our lowering,
-@@ -985,6 +999,7 @@ class GraphNodeImporter:
+         except KeyError as e:
+             raise RuntimeError(
+                 f"FIXME: Illegal access to torch.fx.Node.meta: {e} ({node.meta.keys()} : {node.meta})"
+@@ -1038,6 +1051,7 @@ class GraphNodeImporter:
          "_on_node_produced",
          "_v",
          "_multi_result_nodes",
@@ -37,7 +30,7 @@ index 4eaeb7ac..dac0f755 100644
          "fx_importer",
      ]
  
-@@ -1008,6 +1023,9 @@ class GraphNodeImporter:
+@@ -1061,6 +1075,9 @@ class GraphNodeImporter:
          # They will have their getitem calls short-circuited.
          self._multi_result_nodes: Set[torch_fx.Node] = set()
  
@@ -47,7 +40,7 @@ index 4eaeb7ac..dac0f755 100644
      def bind_node_value(
          self,
          node: Node,
-@@ -1163,6 +1181,23 @@ class GraphNodeImporter:
+@@ -1216,6 +1233,23 @@ class GraphNodeImporter:
                                      f"notify developers if this case happens "
                                      f"(at {loc})."
                                  )
@@ -71,7 +64,7 @@ index 4eaeb7ac..dac0f755 100644
                          else:
                              raise NotImplementedError(
                                  f"General getitem access to non-multi-result ops"
-@@ -1320,6 +1355,10 @@ class GraphNodeImporter:
+@@ -1642,6 +1676,10 @@ class GraphNodeImporter:
              # Unary return directly maps a single meta["val"] and cannot be subscripted.
              # if "tensor_meta" is None, this will throw unsupported placeholder node error
              result_types = [self._cc.node_val_to_type(node)]

--- a/frontends/torch-frontend/torch-frontend/include/torch-frontend/Pipelines/Pipelines.h
+++ b/frontends/torch-frontend/torch-frontend/include/torch-frontend/Pipelines/Pipelines.h
@@ -24,7 +24,7 @@
 namespace mlir {
 namespace torch_frontend {
 
-void createTorchToMhloPipeline(OpPassManager &pm);
+void createTorchToStablehloPipeline(OpPassManager &pm);
 
 void createTorchscriptToTorchPipeline(
     OpPassManager &pm,
@@ -37,7 +37,7 @@ void createTorchFunctionToTorchPipeline(
 inline void registerTorchToMhloPipeline() {
   PassPipelineRegistration<>("torch-to-stablehlo-pipeline",
                              "Torch frontend torch to stablehlo pipeline.",
-                             createTorchToMhloPipeline);
+                             createTorchToStablehloPipeline);
 }
 
 inline void registerTorchscriptToTorchPipeline() {

--- a/frontends/torch-frontend/torch-frontend/lib/Pipelines/CMakeLists.txt
+++ b/frontends/torch-frontend/torch-frontend/lib/Pipelines/CMakeLists.txt
@@ -1,3 +1,6 @@
+# note: remove this when upstream fixed
+target_link_libraries(TorchMLIRTorchConversionPasses PUBLIC TorchMLIRTorchToTensor TorchMLIRTorchToStablehlo)
+
 add_mlir_library(TorchFrontendPipelines
     Pipelines.cpp
 

--- a/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_byteir_customcall_ops.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_byteir_customcall_ops.py
@@ -2,10 +2,10 @@ import torch
 import torch as tu
 
 import torch_frontend
-from torch_frontend import convert_to_mhlo_via_torch_mlir
+from torch_frontend import compile
 
 def custom_test_helper(module, inputs, custom_op_name):
-    mlir_module = convert_to_mhlo_via_torch_mlir(module, inputs)
+    mlir_module = compile(module, inputs, "stablehlo")
     mlir_str = mlir_module.operation.get_asm(large_elements_limit=10, enable_debug_info=False)
     compare_str = "stablehlo.custom_call @{}".format(custom_op_name)
     print(mlir_str)

--- a/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_model.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_model.py
@@ -1,7 +1,7 @@
 import torch
 
 import torch_frontend
-from torch_frontend import convert_to_mhlo_via_torch_mlir
+from torch_frontend import compile
 
 def test_resnet18_compile():
     import torchvision.models as models
@@ -9,7 +9,7 @@ def test_resnet18_compile():
     resnet18.train(False)
     inputs = torch.ones(1, 3, 224, 224)
 
-    module = convert_to_mhlo_via_torch_mlir(resnet18, inputs)
+    module = compile(resnet18, inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 # def test_berttiny_compile():
@@ -30,5 +30,5 @@ def test_resnet18_compile():
 #     fx_g.recompile()
 #     bert = torch.jit.trace(fx_g, inputs)
 
-#     module = convert_to_mhlo_via_torch_mlir(bert, inputs)
+#     module = compile(bert, inputs, "stablehlo")
 #     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))

--- a/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_ops.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_ops.py
@@ -2,7 +2,7 @@ import torch
 import torch as tu
 
 import torch_frontend
-from torch_frontend import convert_to_mhlo_via_torch_mlir
+from torch_frontend import compile
 
 # ==============================================================================
 
@@ -17,7 +17,7 @@ def test_aten_cuda():
     module = AtenCudaModule()
     inputs = [tu.randn(3, 4)]
     module = torch.jit.script(module)
-    module = convert_to_mhlo_via_torch_mlir(module, inputs)
+    module = compile(module, inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 # ==============================================================================
@@ -33,7 +33,7 @@ def test_aten_batch_norm_fp16():
     module = AtenBatchNormFp16Module()
     inputs = [tu.randn(1, 16, 28, 28).half().cuda(), tu.randn(16).cuda()]
     module = torch.jit.script(module)
-    module = convert_to_mhlo_via_torch_mlir(module, inputs)
+    module = compile(module, inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 # ==============================================================================
@@ -50,7 +50,7 @@ def test_cat():
     module = CatModule()
     inputs = [tu.randint(0, 2, (10, 20)).long()]
     module = torch.jit.trace(module, inputs) # x.bool() can't be scripted
-    module = convert_to_mhlo_via_torch_mlir(module , inputs)
+    module = compile(module , inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 # ==============================================================================
@@ -65,7 +65,7 @@ class LinalgVectorNormModule(torch.nn.Module):
 def test_linalg_vector_norm():
     module = LinalgVectorNormModule()
     inputs = [tu.randn(3, 4, 5).to(torch.float16)]
-    module = convert_to_mhlo_via_torch_mlir(module, inputs)
+    module = compile(module, inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 # ==============================================================================
@@ -79,7 +79,7 @@ class MaxDimModule(torch.nn.Module):
 
 def test_max_dim():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(MaxDimModule(), inputs)
+    module = compile(MaxDimModule(), inputs, "stablehlo")
     print(module.operation.get_asm())
 
 class MaxDimKeepDimModule(torch.nn.Module):
@@ -91,7 +91,7 @@ class MaxDimKeepDimModule(torch.nn.Module):
 
 def test_max_dim_keepdim():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(MaxDimKeepDimModule(), inputs)
+    module = compile(MaxDimKeepDimModule(), inputs, "stablehlo")
     print(module.operation.get_asm())
 
 # ==============================================================================
@@ -104,7 +104,7 @@ class ListModule(torch.nn.Module):
 
 def test_return_list():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(ListModule(), inputs)
+    module = compile(ListModule(), inputs, "stablehlo")
     print(module.operation.get_asm())
 
 # ==============================================================================
@@ -119,7 +119,7 @@ class ArangeModule(torch.nn.Module):
 
 def test_arange_derefine():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(ArangeModule(), inputs)
+    module = compile(ArangeModule(), inputs, "stablehlo")
     print(module.operation.get_asm())
 
 class ClampDerefineModule(torch.nn.Module):
@@ -131,7 +131,7 @@ class ClampDerefineModule(torch.nn.Module):
 
 def test_clamp_derefine():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(ClampDerefineModule(), inputs)
+    module = compile(ClampDerefineModule(), inputs, "stablehlo")
     print(module.operation.get_asm())
 
 # ==============================================================================
@@ -145,7 +145,7 @@ class Tuple1Module(torch.nn.Module):
 
 def test_tuple_one_tensor():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(Tuple1Module(), inputs)
+    module = compile(Tuple1Module(), inputs, "stablehlo")
     print(module.operation.get_asm())
 
 class Tuple2Module(torch.nn.Module):
@@ -156,5 +156,5 @@ class Tuple2Module(torch.nn.Module):
 
 def test_tuple_one_tensor():
     inputs = [tu.randn(3, 4)]
-    module = convert_to_mhlo_via_torch_mlir(Tuple2Module(), inputs)
+    module = compile(Tuple2Module(), inputs, "stablehlo")
     print(module.operation.get_asm())

--- a/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_torch_custom_ops.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_torch_custom_ops.py
@@ -2,7 +2,7 @@ import torch
 import torch as tu
 
 import torch_frontend
-from torch_frontend import convert_to_mhlo_via_torch_mlir, replace_flash_attn 
+from torch_frontend import compile, replace_flash_attn 
 from functorch.compile import aot_module
 import functools
 from torch.testing import FileCheck
@@ -25,7 +25,7 @@ def test_dynamic_partition_stitch():
     indices = [torch.tensor([2, 3, 4]), torch.tensor([0, 1])]
     inputs = [data, partitions, indices[0], indices[1]]
     module = torch.jit.script(module)
-    module = convert_to_mhlo_via_torch_mlir(module, inputs)
+    module = compile(module, inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 
@@ -54,7 +54,7 @@ def test_dynamic_partition_mask_stitch():
     partitions = torch.tensor([0, 1, 0, 1, 0])
     inputs = [data, partitions]
     module = torch.jit.script(module)
-    module = convert_to_mhlo_via_torch_mlir(module, inputs)
+    module = compile(module, inputs, "stablehlo")
     print(module.operation.get_asm(large_elements_limit=10, enable_debug_info=False))
 
 

--- a/frontends/torch-frontend/torch-frontend/python/torch_frontend/__init__.py
+++ b/frontends/torch-frontend/torch-frontend/python/torch_frontend/__init__.py
@@ -3,6 +3,6 @@ from ._mlir_libs._torchFrontend import *
 from .compile import DebugType
 
 from .fx_utils import list_decomposed_ops, preprocess_fx_graph, get_none_indices
-from .compile import convert_to_mhlo_via_torch_mlir, compile, compile_dynamo_model
+from .compile import compile, compile_dynamo_model
 from .flash_attn_op import replace_flash_attn
 from .fx_rewrite import fx_replace_attn_pattern


### PR DESCRIPTION
* update torch-mlir to upstream main
* remove deprecated `convert_to_mhlo_via_torch_mlir`, use `compile` instead