### PR TITLE
[compiler] support dynamic shape for memrefcopyToLinalg

### DIFF
--- a/compiler/lib/Conversion/ToLinalg/MemrefCopyToLinalg.cpp
+++ b/compiler/lib/Conversion/ToLinalg/MemrefCopyToLinalg.cpp
@@ -25,17 +25,48 @@
 
 #include "byteir/Conversion/ToLinalg/ToLinalg.h"
 #include "byteir/Dialect/Byre/Common.h"
+#include "byteir/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
+
+#include <queue>
 
 #include "../PassDetail.h"
 
 namespace mlir {
 
 namespace {
+SmallVector<Operation *> collectAllDenpendOps(SmallVector<Operation *> oriOps) {
+  SmallVector<Operation *> retOps;
+  std::queue<Operation *> opQueue;
+
+  for (auto &&op : oriOps) {
+    opQueue.push(op);
+  }
+
+  while (!opQueue.empty()) {
+    auto curOp = opQueue.front();
+    opQueue.pop();
+    if (llvm::find(retOps, curOp) != retOps.end()) {
+      continue;
+    }
+    retOps.emplace_back(curOp);
+    for (auto &&operand : curOp->getOperands()) {
+      if (operand.getType().isa<MemRefType>()) {
+        continue;
+      } else if (auto defOp = operand.getDefiningOp()) {
+        opQueue.push(defOp);
+      }
+    }
+  }
+  computeTopologicalSorting(retOps);
+  return retOps;
+}
+
 struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
   using OpRewritePattern<memref::CopyOp>::OpRewritePattern;
   MemrefCopyOpToLinalg(MLIRContext *ctx, std::string anchorTag,
@@ -72,11 +103,30 @@ struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
       };
       Value callSrc = getViewSource(src);
       Value callDst = getViewSource(dst);
+      SmallVector<Operation *> cloneCluster = collectAllDenpendOps(ops);
+      auto inputs = getInputsOfCluster(llvm::SmallVector<Operation *, 8>(
+          cloneCluster.begin(), cloneCluster.end()));
+
+      if (llvm::find(inputs, callSrc) == inputs.end()) {
+        inputs.push_back(callSrc);
+      }
+
+      // memory effect of dst is write, move to end.
+      if (llvm::find(inputs, callDst) == inputs.end()) {
+        inputs.push_back(callDst);
+      } else {
+        int64_t index = llvm::find(inputs, callDst) - inputs.begin();
+        std::swap(inputs.back(), inputs[index]);
+      }
 
       auto symbolTableOp = SymbolTable::getNearestSymbolTable(copyOp);
       SymbolTable symbolTable(symbolTableOp);
-      auto funcType =
-          rewriter.getFunctionType({callSrc.getType(), callDst.getType()}, {});
+      SmallVector<Type> inputTypes;
+      for (auto &&in : inputs) {
+        inputTypes.emplace_back(in.getType());
+      }
+
+      auto funcType = rewriter.getFunctionType(inputTypes, {});
 
       OpBuilder::InsertionGuard guard(rewriter);
       // Insert before module terminator.
@@ -89,8 +139,8 @@ struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
       Block *entryBlock = funcOp.addEntryBlock();
       rewriter.setInsertionPointToStart(entryBlock);
       IRMapping mapping;
-      mapping.map(ValueRange{callSrc, callDst}, entryBlock->getArguments());
-      for (auto &&op : llvm::reverse(ops)) {
+      mapping.map(inputs, entryBlock->getArguments());
+      for (auto &&op : cloneCluster) {
         auto newOp = rewriter.clone(*op, mapping);
         mapping.map(op, newOp);
       }
@@ -112,10 +162,10 @@ struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
       }
 
       rewriter.setInsertionPoint(copyOp);
-      auto callOp = rewriter.replaceOpWithNewOp<func::CallOp>(
-          copyOp, funcOp, ValueRange{callSrc, callDst});
+      auto callOp =
+          rewriter.replaceOpWithNewOp<func::CallOp>(copyOp, funcOp, inputs);
       callOp->setAttr(byre::getByreCallOpReadonlyOperandNumAttrName(),
-                      rewriter.getIndexAttr(1));
+                      rewriter.getIndexAttr(inputs.size() - 1));
     } else {
       AffineMap id = AffineMap::getMultiDimIdentityMap(dstType.getRank(),
                                                        rewriter.getContext());

--- a/compiler/test/Conversion/ToLinalg/memrefcopyToLinalg.mlir
+++ b/compiler/test/Conversion/ToLinalg/memrefcopyToLinalg.mlir
@@ -11,3 +11,29 @@ func.func @memref_copy(%arg0: memref<2x4xf32>, %arg1: memref<2x2xf32>) {
 //   CHECK-NEXT: linalg.generic
 // CHECK-LABEL: func.func @memref_copy
 //   CHECK-NEXT: call @memref_copy_kernel
+
+// -----
+
+func.func @dynamic_memref_copy(%arg0: memref<?x3xf16>, %arg1: memref<?x3xf16>) -> memref<?x15xf16> {
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %arg0, %c0 : memref<?x3xf16>
+  %alloc = memref.alloc(%dim) : memref<?x15xf16>
+  %subview = memref.subview %alloc[0, 0] [%dim, 3] [1, 1] : memref<?x15xf16> to memref<?x3xf16, strided<[15, 1]>>
+  memref.copy %arg0, %subview : memref<?x3xf16> to memref<?x3xf16, strided<[15, 1]>>
+  %subview_0 = memref.subview %alloc[0, 3] [%dim, 3] [1, 1] : memref<?x15xf16> to memref<?x3xf16, strided<[15, 1], offset: 3>>
+  memref.copy %arg1, %subview_0 : memref<?x3xf16> to memref<?x3xf16, strided<[15, 1], offset: 3>>
+  return %alloc : memref<?x15xf16>
+}
+// CHECK-LABEL: func.func private @memref_copy_kernel
+//   CHECK-SAME: attributes {test}
+//   CHECK: memref.dim
+//   CHECK-NEXT: memref.subview
+//   CHECK-NEXT: linalg.generic
+// CHECK-LABEL: func.func private @memref_copy_kernel_0
+//   CHECK-SAME: attributes {test}
+//   CHECK: memref.dim
+//   CHECK-NEXT: memref.subview
+//   CHECK-NEXT: linalg.generic
+// CHECK-LABEL: func.func @dynamic_memref_copy
+//   CHECK: call @memref_copy_kernel_0
+//   CHECK-NEXT: call @memref_copy_kernel


### PR DESCRIPTION
viewLikeOp may have dynamic shape, size/shape/.. may be results of other ops. 
All dependent ops should be outlining when create `memref_copy_kernel`.
