### PR TITLE
[compiler] fix some bug for reduction

### DIFF
--- a/compiler/lib/Pipelines/LinalgTensorOpt.cpp
+++ b/compiler/lib/Pipelines/LinalgTensorOpt.cpp
@@ -91,6 +91,7 @@ void addGenericLinalgPasses(OpPassManager &pm) {
     GPUTileGridReductionOptions tileGridRedOptions;
     tileGridRedOptions.funcAnchor = reductionAnchor;
     tileGridRedOptions.blockSize = 512;
+    pm.addPass(createLinalgFoldUnitExtentDimsPass());
     createGPUTileGridReductionTransform(pm, tileGridRedOptions);
     pm.addPass(createTransformDialectInterpreter(true));
     {

--- a/tests/numerical_test/torch_e2e_testing/test_suite/basic.py
+++ b/tests/numerical_test/torch_e2e_testing/test_suite/basic.py
@@ -86,3 +86,30 @@ class BatchMatmulAddF32Module(torch.nn.Module):
 @register_test_case(module_factory=lambda: BatchMatmulAddF32Module())
 def BatchMatmulAddF32Module_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 5, 6), tu.rand(2, 6, 10), tu.rand(2, 5, 10))
+
+
+class ReductionPaddingModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, a,):
+        return torch.ops.aten.mean(a)
+
+
+@register_test_case(module_factory=lambda: ReductionPaddingModule())
+def ReductionPaddingModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1023))
+
+class ReductionOneSizeModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, a,):
+        return torch.ops.aten.mean(a,dim=(1))
+
+
+@register_test_case(module_factory=lambda: ReductionOneSizeModule())
+def ReductionOneSizeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1024,1))


### PR DESCRIPTION
This PR fixs three bugs, which are
1) padding the last dim of the input tensor as a multiple of wapsize.
2) adding createLinalgFoldUnitExtentDimsPass before tiling the tersor to blocks to avoid that linalg.generic has several reduction dim and can not be collapsed (The reason is not clear temporary).
3) avoiding to set a reduction attribute to those reduce op which only reduces on dimensions with a size of 1.