### PR TITLE
[fix] Update prepare.sh to prevent deletion of 'external_libs/libs' before rebuilding runtime

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -25,9 +25,9 @@ function install_mhlo_tools() {
 
 function copy_external_libs() {
   PREBUILT_FLASH_ATTN="/data00/external_libraries/libflash_attn.so"
-  mkdir $ROOT_PROJ_DIR/external_libs/libs
+  mkdir -p $ROOT_PROJ_DIR/external_libs/libs
   cp $PREBUILT_FLASH_ATTN $ROOT_PROJ_DIR/external_libs/libs
-  mkdir $ROOT_PROJ_DIR/runtime/test/test_files/external_libs/
+  mkdir -p $ROOT_PROJ_DIR/runtime/test/test_files/external_libs/
   cp $PREBUILT_FLASH_ATTN $ROOT_PROJ_DIR/runtime/test/test_files/external_libs/
 }
 


### PR DESCRIPTION
as title