### PR TITLE
[compiler] rename ReduceFusion to ReduceWindowFusion

### DIFF
--- a/compiler/include/byteir/Dialect/mhlo/Passes.td
+++ b/compiler/include/byteir/Dialect/mhlo/Passes.td
@@ -289,12 +289,12 @@ def LayoutTransformation : Pass<"transform-layout", "mlir::func::FuncOp"> {
 }
 
 //===----------------------------------------------------------------------===//
-// ReduceFusion
+// ReduceWindowFusion
 //===----------------------------------------------------------------------===//
 
-def ReduceFusion : Pass<"fuse-reduce", "mlir::func::FuncOp"> {
-  let summary = "Fuse reduce and reduce-window ops";
-  let constructor = "mlir::createReduceFusionPass()";
+def ReduceWindowFusion : Pass<"fuse-reduce-window", "mlir::func::FuncOp"> {
+  let summary = "Fuse reduce-window with pad op";
+  let constructor = "mlir::createReduceWindowFusionPass()";
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/include/byteir/Dialect/mhlo/Transforms/HloFuser.h
+++ b/compiler/include/byteir/Dialect/mhlo/Transforms/HloFuser.h
@@ -34,8 +34,8 @@ constexpr StringRef getByteIRCatFusionAttrName() {
   return "__byteir_cat_fusion__";
 }
 
-constexpr StringRef getByteIRReduceFusionAttrName() {
-  return "__byteir_reduce_fusion__";
+constexpr StringRef getByteIRReduceWindowFusionAttrName() {
+  return "__byteir_reduce_window_fusion__";
 }
 
 constexpr StringRef getByteIRElementwiseFusionAttrName() {
@@ -58,7 +58,7 @@ constexpr StringRef getByteIRHloAggressiveFusionAttrName() {
   return "__byteir_hlo_aggressive_fusion__";
 }
 
-// fuse ReduceWindow with Pad and/or Constant
+// fuse ReduceWindow with Pad
 void populateFuseReduceWindowPatterns(RewritePatternSet &patterns);
 
 // fuse ConvForward patterns
@@ -78,7 +78,7 @@ void populateIOConvertBatchNormPattern(RewritePatternSet &patterns);
 void populateTrivialFusionPattern(RewritePatternSet &patterns,
                                   llvm::StringMap<StringRef> &lut_name);
 
-std::unique_ptr<OperationPass<func::FuncOp>> createReduceFusionPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createReduceWindowFusionPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createConvBackwardFusionPass();
 

--- a/compiler/lib/Dialect/mhlo/CMakeLists.txt
+++ b/compiler/lib/Dialect/mhlo/CMakeLists.txt
@@ -103,7 +103,7 @@ add_mlir_dialect_library(ByteIRMhloPasses
   Transforms/InsertShapeConstraint.cpp
   Transforms/IOConvertFusion.cpp
   Transforms/LayoutTransformation.cpp
-  Transforms/ReduceFusion.cpp
+  Transforms/ReduceWindowFusion.cpp
   Transforms/RewriteWithConstraint.cpp
   Transforms/ShapeReification.cpp
   Transforms/StaticShapeInference.cpp

--- a/compiler/lib/Dialect/mhlo/Transforms/ReduceWindowFusion.cpp
+++ b/compiler/lib/Dialect/mhlo/Transforms/ReduceWindowFusion.cpp
@@ -84,16 +84,17 @@ struct PadReduceWindowPattern : public OpRewritePattern<mhlo::ReduceWindowOp> {
     auto fusion = *createMhloFusionFromPattern(rewriter, pattern);
 
     // add attr
-    fusion->setAttr(getByteIRReduceFusionAttrName(),
+    fusion->setAttr(getByteIRReduceWindowFusionAttrName(),
                     UnitAttr::get(fusion.getContext()));
 
     return success();
   }
 };
 
-struct ReduceFusionPass : public ReduceFusionBase<ReduceFusionPass> {
+struct ReduceWindowFusionPass
+    : public ReduceWindowFusionBase<ReduceWindowFusionPass> {
 
-  ReduceFusionPass() : ReduceFusionBase() {}
+  ReduceWindowFusionPass() : ReduceWindowFusionBase() {}
 
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
@@ -102,8 +103,8 @@ struct ReduceFusionPass : public ReduceFusionBase<ReduceFusionPass> {
     populateFuseReduceWindowPatterns(patterns);
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
     if (failed(applyPatternsAndFoldGreedily(funcOp, frozenPatterns))) {
-      funcOp.emitError(
-          "ReduceFusionPass applyPatternsAndFoldGreedily does not converge");
+      funcOp.emitError("ReduceWindowFusionPass applyPatternsAndFoldGreedily "
+                       "does not converge");
       signalPassFailure();
     }
   }
@@ -114,6 +115,7 @@ void mlir::populateFuseReduceWindowPatterns(RewritePatternSet &patterns) {
   patterns.add<PadReduceWindowPattern>(patterns.getContext());
 }
 
-std::unique_ptr<OperationPass<func::FuncOp>> mlir::createReduceFusionPass() {
-  return std::make_unique<ReduceFusionPass>();
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createReduceWindowFusionPass() {
+  return std::make_unique<ReduceWindowFusionPass>();
 }

--- a/compiler/lib/Pipelines/HloOpt.cpp
+++ b/compiler/lib/Pipelines/HloOpt.cpp
@@ -85,12 +85,12 @@ void createHloOptPipelineImpl(OpPassManager &pm, const std::string &entryFunc,
 
   addCleanUpExtPassPipeline(pm);
 
-  // generic folding
+  // generic folding and simplify
+  pm.addNestedPass<func::FuncOp>(createUnfuseBatchNormPass());
   pm.addNestedPass<func::FuncOp>(createHloFolderPass());
   pm.addNestedPass<func::FuncOp>(createHloFolderPass());
-  pm.addNestedPass<func::FuncOp>(createHloTransposeDotToDotGeneralPass());
-  pm.addNestedPass<func::FuncOp>(createReduceFusionPass());
   pm.addNestedPass<func::FuncOp>(createHloSimplifyPass());
+  pm.addNestedPass<func::FuncOp>(createHloTransposeDotToDotGeneralPass());
   pm.addPass(createConvertOpToCustomCallPass());
 
   // rewrite with constraint

--- a/compiler/test/Dialect/Mhlo/transforms/reduceFusion.mlir
+++ b/compiler/test/Dialect/Mhlo/transforms/reduceFusion.mlir
@@ -1,4 +1,4 @@
-// RUN: byteir-opt %s -fuse-reduce | FileCheck %s
+// RUN: byteir-opt %s -fuse-reduce-window | FileCheck %s
 
 func.func @reduce_window_pad_and_const_ini(%arg0: tensor<32x64x112x112xf16>, %arg1: tensor<f16>) -> tensor<32x64x56x56xf16>{
   %0 = mhlo.constant dense<0xFC00> : tensor<f16>


### PR DESCRIPTION
* because there is another ReductionFusionPass. The name `ReduceFusion` is confusing.
* remove `ReduceFusion` from `HloOpt` as it's unsupported in current pipeline.
* add `UnfuseBatchNorm` to `HloOpt`, so that https://github.com/bytedance/byteir/issues/269 could be resolved.