### PR TITLE
[CCL] Fix broadcast

### DIFF
--- a/runtime/test/backends/nccl/providers/test_distributed_session.cc
+++ b/runtime/test/backends/nccl/providers/test_distributed_session.cc
@@ -376,3 +376,69 @@ TEST(TestDistributedSession, NCCLBroadcast) {
     threads[i].join();
   }
 }
+
+TEST(TestDistributedSession, NCCLBroadcast2) {
+  const int nranks = 4;
+  const std::string host = "localhost";
+  int port = brt::GetFreePort();
+  auto ret = brt::CreateServer(nranks, port);
+  ASSERT_EQ(Status::OK(), ret);
+
+  auto run = [nranks, host, port](int rank) {
+    int local_rank = rank;
+    DistributedSession d_session(rank, nranks, host, port);
+    auto status_allocator = CUDAAllocatorFactory(&d_session, local_rank);
+    BRT_TEST_CHECK_STATUS(status_allocator);
+    auto status_cuda =
+        DefaultNCCLExecutionProviderFactory(&d_session, local_rank);
+    BRT_TEST_CHECK_STATUS(status_cuda);
+
+    std::vector<std::string> config = {
+        "test/test_files/Distributed/broadcast2.mlir",
+        "test/test_files/Distributed/broadcast2.mlir",
+        "test/test_files/Distributed/broadcast2.mlir",
+        "test/test_files/Distributed/broadcast2.mlir"};
+    std::string ir_url;
+    d_session.LoadConfig(config, ir_url);
+    auto status_load = d_session.Load(ir_url, "byre");
+    BRT_TEST_CHECK_STATUS(status_load);
+
+    std::unique_ptr<RequestContext> request;
+    auto status_request = d_session.NewRequestContext(&request);
+    BRT_TEST_CHECK_STATUS(status_request);
+
+    auto src_shape = d_session.GetStaticShape(0);
+    int64_t src_linearized_shape = LinearizedShape(src_shape);
+    EXPECT_GT(src_linearized_shape, 0);
+    size_t src_len = static_cast<size_t>(src_linearized_shape);
+    float *src = (float *)request->GetArg(0);
+    if (rank == 0) {
+      AssignCUDABuffer(src, src_len, 0.0f);
+    } else if (rank == 1) {
+      AssignCUDABuffer(src, src_len, 1.0f);
+    } else if (rank == 2) {
+      AssignCUDABuffer(src, src_len, 2.0f);
+    } else if (rank == 3) {
+      AssignCUDABuffer(src, src_len, 3.0f);
+    }
+    request->FinishIOBinding();
+    auto status_run = d_session.Run(*request);
+    BRT_TEST_CHECK_STATUS(status_run);
+    auto status_sync = request->Sync();
+    BRT_TEST_CHECK_STATUS(status_sync);
+    if (rank == 1) {
+      CheckResult(src, src_len, 1.0f);
+    } else {
+      CheckResult(src, src_len, 2.0f);
+    }
+  };
+
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < nranks; i++) {
+    threads.push_back(std::thread(run, i));
+  }
+
+  for (size_t i = 0; i < nranks; i++) {
+    threads[i].join();
+  }
+}

--- a/runtime/test/test_files/Distributed/broadcast2.mlir
+++ b/runtime/test/test_files/Distributed/broadcast2.mlir
@@ -1,0 +1,6 @@
+module attributes {byre.container_module} {
+  func.func @test_broadcast(%arg0 : memref<8xf32, "cuda"> {byre.argname = "in0", byre.argtype = 1: i32}) attributes {byre.entry_point} {
+    byre.compute @nccl.Broadcast(%arg0) {replica_group = [2, 0, 3]} : memref<8xf32, "cuda">
+    return
+  }
+}


### PR DESCRIPTION
Origin case will fail in this case:
```
byre.compute @nccl.Broadcast(%arg0) {replica_group = [2, 0, 3]} : memref<8xf32, "cuda">
```
As root == 2, but after ncclCommSplit, the new rank will be "1, 0, 2". So it will fail because the wrong root is appointed.

