### PR TITLE
[compiler] fix DeviceGraphCluster for if op

### DIFF
--- a/compiler/include/byteir/Dialect/Shape/IR/ShapeExtBase.td
+++ b/compiler/include/byteir/Dialect/Shape/IR/ShapeExtBase.td
@@ -26,7 +26,7 @@ def ShapeExtDialect : Dialect {
   let summary = "Extension for shape dialect";
 
   let cppNamespace = "::mlir::shape_ext";
-  let dependentDialects = ["arith::ArithDialect", "tensor::TensorDialect", "shape::ShapeDialect"];
+  let dependentDialects = ["arith::ArithDialect", "tensor::TensorDialect", "shape::ShapeDialect", "scf::SCFDialect"];
 
   // let useDefaultTypePrinterParser = 1;
   // let hasConstantMaterializer = 1;

--- a/compiler/include/byteir/Dialect/Shape/Passes.td
+++ b/compiler/include/byteir/Dialect/Shape/Passes.td
@@ -44,6 +44,7 @@ def InsertTieShape : Pass<"insert-tie-shape", "mlir::func::FuncOp"> {
   }];
   let constructor = "mlir::createInsertTieShapePass()";
   let dependentDialects = [
+    "mlir::mhlo::MhloDialect",
     "mlir::shape_ext::ShapeExtDialect",
     "mlir::tensor::TensorDialect",
   ];

--- a/compiler/include/byteir/Dialect/mhlo/Analysis/ShapeAnalysis.h
+++ b/compiler/include/byteir/Dialect/mhlo/Analysis/ShapeAnalysis.h
@@ -21,6 +21,62 @@
 #include "byteir/Analysis/ShapeAnalysis.h"
 
 namespace mlir {
+namespace value_analysis {
+struct BoundedValueKnowledge {
+  struct BoundedValue {
+    Attribute lower;
+    Attribute upper;
+    bool operator==(const BoundedValue &rhs) const {
+      return lower == rhs.lower && upper == rhs.upper;
+    }
+    bool isUnknwon() const { return (!lower) || (!upper); }
+  };
+  explicit BoundedValueKnowledge() = default;
+  explicit BoundedValueKnowledge(BoundedValue bdValue)
+      : boundedValue(bdValue) {}
+  explicit BoundedValueKnowledge(Attribute lower, Attribute upper) {
+    BoundedValue bv;
+    bv.lower = lower;
+    bv.upper = upper;
+    boundedValue = bv;
+  }
+
+  // Get the static knowledge intrinsic to `type`.
+  static BoundedValueKnowledge getUninitializedValue();
+
+  static BoundedValueKnowledge getUnknownValue();
+
+  static BoundedValueKnowledge getKnownValue(Attribute lower, Attribute upper);
+
+  static BoundedValueKnowledge join(const BoundedValueKnowledge &lhs,
+                                    const BoundedValueKnowledge &rhs);
+
+  static BoundedValueKnowledge meet(const BoundedValueKnowledge &lhs,
+                                    const BoundedValueKnowledge &rhs);
+
+  /// Whether the state is uninitialized.
+  bool isUninitialized() const { return !boundedValue.has_value(); }
+
+  bool isUnknown() const {
+    return boundedValue.has_value() && boundedValue->isUnknwon();
+  }
+
+  bool isKnown() const {
+    return boundedValue.has_value() && !boundedValue->isUnknwon();
+  }
+
+  bool operator==(const BoundedValueKnowledge &rhs) const {
+    return boundedValue == rhs.boundedValue;
+  }
+
+  Attribute lower() const;
+  Attribute upper() const;
+
+  void print(raw_ostream &os) const;
+
+  std::optional<BoundedValue> boundedValue;
+};
+} // namespace value_analysis
 
 class MhloShapeAnalysis : public ShapeAnalysis {
 public:
@@ -55,10 +111,15 @@ public:
       llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results) override;
 };
 
-class MhloBoundedValueAnalysis : public BoundedValueAnalysis {
-public:
-  using BoundedValueAnalysis::BoundedValueAnalysis;
+using BoundedValueLattice =
+    dataflow::Lattice<value_analysis::BoundedValueKnowledge>;
 
+class MhloBoundedValueAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<BoundedValueLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  void setToEntryState(BoundedValueLattice *lattice) override;
   void visitOperation(Operation *op,
                       ArrayRef<const BoundedValueLattice *> operands,
                       ArrayRef<BoundedValueLattice *> results) override;

--- a/compiler/include/byteir/Dialect/mhlo/Passes.td
+++ b/compiler/include/byteir/Dialect/mhlo/Passes.td
@@ -34,6 +34,9 @@ def BoundedShapeInference : Pass<"bounded-shape-infer", "func::FuncOp"> {
     and reuse the static operations' shape inference implementation. 
   }];
   let constructor = "mlir::createBoundedShapeInferencePass()";
+  let dependentDialects = [
+    "mlir::scf::SCFDialect"
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/lib/Dialect/Shape/CMakeLists.txt
+++ b/compiler/lib/Dialect/Shape/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_dialect_library(ByteIRShapePasses
   ByteIRShapePassIncGen
   ByteIRUtils
   MLIRShapeExt
+  MhloDialect
 
   LINK_LIBS PUBLIC
   ByteIRUtils

--- a/compiler/lib/Dialect/Shape/IR/ShapeExtOps.cpp
+++ b/compiler/lib/Dialect/Shape/IR/ShapeExtOps.cpp
@@ -18,6 +18,7 @@
 #include "byteir/Dialect/Shape/IR/ShapeExtOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Matchers.h"
@@ -42,6 +43,69 @@ namespace {
 
 struct TieWithConst : public OpRewritePattern<shape_ext::TieOp> {
   using OpRewritePattern<shape_ext::TieOp>::OpRewritePattern;
+
+  void setTypeForScfIf(PatternRewriter &rewriter, Value value,
+                       RankedTensorType &originShapeType,
+                       SmallVector<int64_t> &newShape) const {
+    auto newShapeType = originShapeType.clone(newShape);
+    if (value.getDefiningOp() && dyn_cast<scf::IfOp>(value.getDefiningOp())) {
+      SmallVector<int64_t> originShape =
+          llvm::to_vector(originShapeType.getShape());
+      auto opResult = dyn_cast<OpResult>(value);
+      auto ifOp = dyn_cast<scf::IfOp>(value.getDefiningOp());
+      auto thenYield = ifOp.thenYield();
+      auto elseYield = ifOp.elseYield();
+      auto thenValue = thenYield.getResults()[opResult.getResultNumber()];
+      auto elseValue = elseYield.getResults()[opResult.getResultNumber()];
+      thenValue.setType(newShapeType);
+      elseValue.setType(newShapeType);
+
+      int64_t index = 0;
+      SmallVector<int64_t> removeIndex;
+      for (int64_t i = 0; i < newShape.size(); ++i) {
+        if (originShape[i] == ShapedType::kDynamic) {
+          if (newShape[i] == ShapedType::kDynamic) {
+            removeIndex.push_back(index);
+          }
+          index++;
+        }
+      }
+      for (auto *user : thenValue.getUsers()) {
+        if (dyn_cast<shape_ext::TieOp>(user)) {
+          auto tieOp = dyn_cast<shape_ext::TieOp>(user);
+          auto originDims = tieOp.getDims();
+          SmallVector<Value> newDims;
+          for (auto ind : removeIndex) {
+            newDims.push_back(originDims[ind]);
+          }
+          if (!newDims.empty()) {
+            PatternRewriter::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPoint(user);
+            rewriter.create<shape_ext::TieOp>(user->getLoc(), thenValue,
+                                              newDims);
+          }
+          user->erase();
+        }
+      }
+      for (auto *user : elseValue.getUsers()) {
+        if (dyn_cast<shape_ext::TieOp>(user)) {
+          auto tieOp = dyn_cast<shape_ext::TieOp>(user);
+          auto originDims = tieOp.getDims();
+          SmallVector<Value> newDims;
+          for (auto ind : removeIndex) {
+            newDims.push_back(originDims[ind]);
+          }
+          if (!newDims.empty()) {
+            PatternRewriter::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPoint(user);
+            rewriter.create<shape_ext::TieOp>(user->getLoc(), thenValue,
+                                              newDims);
+          }
+          user->erase();
+        }
+      }
+    }
+  }
 
   LogicalResult matchAndRewrite(shape_ext::TieOp op,
                                 PatternRewriter &rewriter) const override {
@@ -77,6 +141,8 @@ struct TieWithConst : public OpRewritePattern<shape_ext::TieOp> {
     if (keepedDims.size() == dims.size())
       return failure();
     value.setType(shapeType.clone(shape));
+    setTypeForScfIf(rewriter, value, shapeType, shape);
+
     func::FuncOp funcOp = op->getParentOfType<func::FuncOp>();
     if (keepedDims.size() == 0) {
       op->erase();

--- a/compiler/lib/Dialect/Shape/Transforms/PassDetail.h
+++ b/compiler/lib/Dialect/Shape/Transforms/PassDetail.h
@@ -36,6 +36,10 @@ namespace shape_ext {
 class ShapeExtDialect;
 } // namespace shape_ext
 
+namespace mhlo {
+class MhloDialect;
+} // namespace mhlo
+
 #define GEN_PASS_CLASSES
 #include "byteir/Dialect/Shape/Passes.h.inc"
 

--- a/compiler/lib/Dialect/mhlo/CMakeLists.txt
+++ b/compiler/lib/Dialect/mhlo/CMakeLists.txt
@@ -117,6 +117,7 @@ add_mlir_dialect_library(ByteIRMhloPasses
   ByteIRMhloPassIncGen
   ByteIRAnalysis
   MhloDialect
+  MLIRSCFDialect
   ByteIRMhloUtils
   ByteIRUtils
   ByteIRMhloAnalysis
@@ -126,6 +127,7 @@ add_mlir_dialect_library(ByteIRMhloPasses
   LINK_LIBS PUBLIC
   MLIRIR
   MhloDialect
+  MLIRSCFDialect
   MLIRMhloUtils
   MLIRSideEffectInterfaces
   MLIRSupport

--- a/compiler/lib/Dialect/mhlo/Transforms/BoundedShapeInference.cpp
+++ b/compiler/lib/Dialect/mhlo/Transforms/BoundedShapeInference.cpp
@@ -24,6 +24,7 @@
 #include "mhlo/IR/hlo_ops.h"
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
@@ -168,6 +169,31 @@ struct BoundedShapeInferencePass
       });
     }
     assert(returnOp && "there must be return op in func");
+    funcOp->walk([&](scf::IfOp op) {
+      auto resultTypes = op->getResultTypes();
+      auto *thenBlock = op.thenBlock();
+      auto *elseBlock = op.elseBlock();
+      if (thenBlock) {
+        auto *retOp = thenBlock->getTerminator();
+        auto operands = retOp->getOperands();
+        assert(operands.size() == resultTypes.size());
+        for (auto it : llvm::zip(operands, resultTypes)) {
+          auto operand = std::get<0>(it);
+          auto type = std::get<1>(it);
+          operand.setType(type);
+        }
+      }
+      if (elseBlock) {
+        auto *retOp = elseBlock->getTerminator();
+        auto operands = retOp->getOperands();
+        assert(operands.size() == resultTypes.size());
+        for (auto it : llvm::zip(operands, resultTypes)) {
+          auto operand = std::get<0>(it);
+          auto type = std::get<1>(it);
+          operand.setType(type);
+        }
+      }
+    });
 
     auto newFuncRetTypes = llvm::to_vector(returnOp.getOperandTypes());
     auto newFuncType =

--- a/compiler/lib/Dialect/mhlo/Transforms/PassDetail.h
+++ b/compiler/lib/Dialect/mhlo/Transforms/PassDetail.h
@@ -46,6 +46,10 @@ namespace tensor {
 class TensorDialect;
 }
 
+namespace scf {
+class SCFDialect;
+}
+
 #define GEN_PASS_CLASSES
 #include "byteir/Dialect/mhlo/Passes.h.inc"
 

--- a/compiler/lib/Transforms/CMakeLists.txt
+++ b/compiler/lib/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_mlir_library(ByteIRTransforms
   ByteIRTensorPasses
   ByteIRTransformsPassIncGen
   ByteIRUtils
+  MLIRSCFDialect
 
   LINK_LIBS PUBLIC
   ByteIRAnalysis


### PR DESCRIPTION
1. support nested region such as scf.if for GraphClusteringByDevice pass
2. scf.if output type compatibility
    a. do not insert shape_ext.TieOp after a mhlo.ConvertOp when Convert static shape op to dynamic shape op
    b. set return type for thenBlock and elseBlock for scf.ifOp when the shape of the return value of scf.ifOp can be deduced 
        by shape_ext.tieOp
    c. set bounded shape for thenBlock and elseBlok of scf.ifOp to meet the compatibility requirements of scf.ifop return 
        types
3. move BoundedValueKnowledge to mhlo/Analysis/ShapeAnalysis.h