### PR TITLE
[compiler] fix DeviceGraphCluster for if op

### DIFF
--- a/compiler/include/byteir/Analysis/ShapeAnalysis.h
+++ b/compiler/include/byteir/Analysis/ShapeAnalysis.h
@@ -20,28 +20,36 @@
 
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "shape-analysis"
 
 namespace mlir {
 namespace shape_analysis {
 /// Statically known information for a particular Value.
 ///
 /// This struct currently tracks only information relevant for tensor/array-like
-/// shaped types. It is fine to associate a `ValueKnowledge` with a non-shaped
-/// type as long as it is in the default "no knowledge" state returned by
-/// `getPessimisticValueState`. The important invariant is that we cannot
-/// claim to know something about a value which is false.
+/// shaped types. It is fine to associate a `StaticShapeKnowledge` with a
+/// non-shaped type as long as it is in the default "no knowledge" state
+/// returned by `getPessimisticValueState`. The important invariant is that we
+/// cannot claim to know something about a value which is false.
 ///
 /// This class could also be called "dataflow facts", "lattice value", etc.
-struct ValueKnowledge {
-  ValueKnowledge() : hasError(false), hasRank(false), dtype(std::nullopt) {}
+struct StaticShapeKnowledge {
+  StaticShapeKnowledge()
+      : hasError(false), hasRank(false), dtype(std::nullopt) {}
 
-  ValueKnowledge(bool hasRank, llvm::ArrayRef<int64_t> newSizes,
-                 std::optional<Type> dtype)
+  StaticShapeKnowledge(bool hasRank, llvm::ArrayRef<int64_t> newSizes,
+                       std::optional<Type> dtype)
       : hasError(false), hasRank(hasRank), dtype(dtype) {
     sizes.reserve(newSizes.size());
     for (auto size : newSizes)
@@ -51,13 +59,13 @@ struct ValueKnowledge {
   operator bool() const { return !hasError; }
 
   // Get the static knowledge intrinsic to `type`.
-  static ValueKnowledge getKnowledgeFromType(Type type);
+  static StaticShapeKnowledge getKnowledgeFromType(Type type);
 
   // Return a pessimistic/conservative value state without assuming any knowlege
   // about the IR.
-  static ValueKnowledge getPessimisticValueState();
+  static StaticShapeKnowledge getPessimisticValueState();
 
-  static ValueKnowledge getPessimisticValueState(Value value);
+  static StaticShapeKnowledge getPessimisticValueState(Value value);
 
   /// Whether the state is uninitialized.
   bool isUninitialized() const { return !dtype.has_value(); }
@@ -72,15 +80,15 @@ struct ValueKnowledge {
     return UnrankedTensorType::get(*dtype);
   }
 
-  bool operator==(const ValueKnowledge &rhs) const {
+  bool operator==(const StaticShapeKnowledge &rhs) const {
     return hasRank == rhs.hasRank && sizes == rhs.sizes && dtype == rhs.dtype;
   }
 
-  static ValueKnowledge join(const ValueKnowledge &lhs,
-                             const ValueKnowledge &rhs);
+  static StaticShapeKnowledge join(const StaticShapeKnowledge &lhs,
+                                   const StaticShapeKnowledge &rhs);
 
-  static ValueKnowledge meet(const ValueKnowledge &lhs,
-                             const ValueKnowledge &rhs);
+  static StaticShapeKnowledge meet(const StaticShapeKnowledge &lhs,
+                                   const StaticShapeKnowledge &rhs);
 
   void print(raw_ostream &os) const;
 
@@ -93,8 +101,25 @@ struct ValueKnowledge {
   llvm::SmallVector<int64_t> sizes;
   // The dtype of a tensor.
   // This is equal to nullptr if we don't know that it is a specific concrete
-  // type. The ValueKnowledge object is isUninitialized if dtype is None.
+  // type. The StaticShapeKnowledge object is isUninitialized if dtype is None.
   std::optional<Type> dtype;
+};
+
+class BoundedShapeKnowledge : public StaticShapeKnowledge {
+public:
+  BoundedShapeKnowledge() : StaticShapeKnowledge() {}
+
+  BoundedShapeKnowledge(bool hasRank, llvm::ArrayRef<int64_t> newSizes,
+                        std::optional<Type> dtype)
+      : StaticShapeKnowledge(hasRank, newSizes, dtype) {}
+
+  static BoundedShapeKnowledge getKnowledgeFromType(Type type);
+  static BoundedShapeKnowledge getPessimisticValueState();
+  static BoundedShapeKnowledge getPessimisticValueState(Value value);
+  static BoundedShapeKnowledge join(const BoundedShapeKnowledge &lhs,
+                                    const BoundedShapeKnowledge &rhs);
+  static BoundedShapeKnowledge meet(const BoundedShapeKnowledge &lhs,
+                                    const BoundedShapeKnowledge &rhs);
 };
 
 struct ValueTypeModificatoinRAII {
@@ -113,102 +138,271 @@ struct ValueTypeModificatoinRAII {
   SmallVector<std::pair<Value, Type>> toRestore;
 };
 } // namespace shape_analysis
-
-namespace value_analysis {
-struct BoundedValueKnowledge {
-  struct BoundedValue {
-    Attribute lower;
-    Attribute upper;
-    bool operator==(const BoundedValue &rhs) const {
-      return lower == rhs.lower && upper == rhs.upper;
-    }
-    bool isUnknwon() const { return (!lower) || (!upper); }
-  };
-  explicit BoundedValueKnowledge() = default;
-  explicit BoundedValueKnowledge(BoundedValue bdValue)
-      : boundedValue(bdValue) {}
-  explicit BoundedValueKnowledge(Attribute lower, Attribute upper) {
-    BoundedValue bv;
-    bv.lower = lower;
-    bv.upper = upper;
-    boundedValue = bv;
-  }
-
-  // Get the static knowledge intrinsic to `type`.
-  static BoundedValueKnowledge getUninitializedValue();
-
-  static BoundedValueKnowledge getUnknownValue();
-
-  static BoundedValueKnowledge getKnownValue(Attribute lower, Attribute upper);
-
-  static BoundedValueKnowledge join(const BoundedValueKnowledge &lhs,
-                                    const BoundedValueKnowledge &rhs);
-
-  static BoundedValueKnowledge meet(const BoundedValueKnowledge &lhs,
-                                    const BoundedValueKnowledge &rhs);
-
-  /// Whether the state is uninitialized.
-  bool isUninitialized() const { return !boundedValue.has_value(); }
-
-  bool isUnknown() const {
-    return boundedValue.has_value() && boundedValue->isUnknwon();
-  }
-
-  bool isKnown() const {
-    return boundedValue.has_value() && !boundedValue->isUnknwon();
-  }
-
-  bool operator==(const BoundedValueKnowledge &rhs) const {
-    return boundedValue == rhs.boundedValue;
-  }
-
-  Attribute lower() const;
-  Attribute upper() const;
-
-  void print(raw_ostream &os) const;
-
-  std::optional<BoundedValue> boundedValue;
-};
-} // namespace value_analysis
-
-using ShapeLattice = dataflow::Lattice<shape_analysis::ValueKnowledge>;
-
-class ShapeAnalysis
-    : public dataflow::SparseForwardDataFlowAnalysis<ShapeLattice> {
-public:
-  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
-
-  void visitOperation(Operation *op, ArrayRef<const ShapeLattice *> operands,
-                      ArrayRef<ShapeLattice *> results) override;
-
-  void setToEntryState(ShapeLattice *lattice) override;
-
-protected:
-  using ShapeKnowledges = function_ref<Type(Value)>;
-  using ShapeValueKnowledges = function_ref<Attribute(Value)>;
-
-  virtual LogicalResult inferResultShapesWithKnowledges(
-      Operation *op, ShapeKnowledges shapeKnowledges,
-      ShapeValueKnowledges shapeValueKnowledges,
-      llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results);
-};
-
 // FIXME: strictly speaking ShapeValueLattice should be a 1-d tensor which could
 // be inferred partially, here we use the same Lattice as the CPA did, so once
 // the state of the Lattice is mutated the subscribed CPA would be triggered
 using ShapeValueLattice = dataflow::Lattice<dataflow::ConstantValue>;
 
+using ShapeKnowledges = function_ref<Type(Value)>;
+using ShapeValueKnowledges = function_ref<Attribute(Value)>;
+
+template <typename ShapeKnowledgeType>
+class ShapeAnalysis : public dataflow::SparseForwardDataFlowAnalysis<
+                          dataflow::Lattice<ShapeKnowledgeType>> {
+public:
+  using ShapeLattice = dataflow::Lattice<ShapeKnowledgeType>;
+  using BaseT = dataflow::SparseForwardDataFlowAnalysis<ShapeLattice>;
+  using BaseT::SparseForwardDataFlowAnalysis;
+
+  void visitOperation(Operation *op, ArrayRef<const ShapeLattice *> operands,
+                      ArrayRef<ShapeLattice *> results) override {
+
+    LLVM_DEBUG(llvm::dbgs() << "shape analysis on " << *op << "\n");
+
+    llvm::DenseMap<Value, Type> shapeProvider;
+    llvm::DenseMap<Value, Attribute> valueProvider;
+    bool missingValue = false;
+    for (auto &&pi : llvm::zip(op->getOperands(), operands)) {
+      auto &&operand = std::get<0>(pi);
+      auto &&shapeLattice = std::get<1>(pi);
+      auto &&valueLattice =
+          this->template getOrCreate<ShapeValueLattice>(operand);
+      valueLattice->useDefSubscribe(this);
+
+      if (auto shapeKnowledge = shapeLattice->getValue()) {
+        if (shapeKnowledge.isUninitialized()) {
+          missingValue = true;
+          continue;
+        }
+      }
+
+      if (valueLattice->getValue().isUninitialized()) {
+        missingValue = true;
+        continue;
+      }
+
+      if (auto shapeKnowledge = shapeLattice->getValue()) {
+        if (*shapeKnowledge.dtype) {
+          shapeProvider[operand] = shapeKnowledge.getType();
+        }
+      }
+
+      if (valueLattice->getValue().getConstantValue()) {
+        valueProvider[operand] = valueLattice->getValue().getConstantValue();
+      }
+    }
+
+    if (missingValue) {
+      return;
+    }
+
+    auto shapeKnowledges = [&](Value val) -> Type {
+      auto it = shapeProvider.find(val);
+      if (it == shapeProvider.end())
+        return nullptr;
+      return it->second;
+    };
+    auto shapeValueKnowledges = [&](Value val) -> Attribute {
+      auto it = valueProvider.find(val);
+      if (it == valueProvider.end())
+        return nullptr;
+      return it->second;
+    };
+
+    SmallVector<ShapedTypeComponents> inferredShapes;
+    if (inferResultShapesWithKnowledges(op, shapeKnowledges,
+                                        shapeValueKnowledges, inferredShapes)
+            .succeeded()) {
+      for (auto it : llvm::zip(op->getResults(), inferredShapes, results)) {
+        Value result = std::get<0>(it);
+        ShapedTypeComponents predictedShape = std::get<1>(it);
+        ShapeLattice *resultLattice = std::get<2>(it);
+
+        Type resultTy = result.getType();
+        if (!isa<ShapedType>(resultTy)) {
+          setToEntryState(resultLattice);
+          continue;
+        }
+
+        // Compute the knowledge based on the inferred type.
+        auto inferredKnowledge = ShapeKnowledgeType::getPessimisticValueState();
+        inferredKnowledge.dtype = cast<ShapedType>(resultTy).getElementType();
+        inferredKnowledge.hasRank = predictedShape.hasRank();
+        if (predictedShape.hasRank()) {
+          for (auto dim : predictedShape.getDims()) {
+            inferredKnowledge.sizes.push_back(dim);
+          }
+        }
+
+        this->template propagateIfChanged(
+            resultLattice, resultLattice->join(inferredKnowledge));
+      }
+    } else {
+      return this->template setAllToEntryStates(results);
+    }
+  }
+
+  void setToEntryState(ShapeLattice *lattice) override {
+    this->template propagateIfChanged(
+        lattice, lattice->join(ShapeKnowledgeType::getPessimisticValueState(
+                     lattice->getPoint())));
+  }
+
+protected:
+  virtual LogicalResult inferResultShapesWithKnowledges(
+      Operation *op, ShapeKnowledges shapeKnowledges,
+      ShapeValueKnowledges shapeValueKnowledges,
+      llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results) {
+    if (op->hasTrait<OpTrait::SameOperandsAndResultShape>()) {
+      ShapeKnowledgeType knowledge; // uninitialized
+      for (auto &&operand : op->getOperands()) {
+        auto newKnowledge =
+            ShapeKnowledgeType::getKnowledgeFromType(shapeKnowledges(operand));
+        newKnowledge.dtype = nullptr;
+        knowledge = ShapeKnowledgeType::meet(knowledge, newKnowledge);
+      }
+      if (knowledge) {
+        for (auto &&resultType : op->getResultTypes()) {
+          if (auto shapedType = dyn_cast_or_null<ShapedType>(resultType)) {
+            knowledge.dtype = shapedType.getElementType();
+            results.push_back(cast<ShapedType>(knowledge.getType()));
+          } else {
+            results.push_back(ShapedTypeComponents{});
+          }
+        }
+        return success();
+      }
+    }
+
+    if (auto shapeInterface = dyn_cast<InferShapedTypeOpInterface>(op)) {
+      shape_analysis::ValueTypeModificatoinRAII valueTypeModification;
+      for (auto &&operand : op->getOperands()) {
+        if (auto shape = shapeKnowledges(operand)) {
+          valueTypeModification.Push(operand, shape);
+        }
+      }
+      ValueShapeRange range(op->getOperands(), shapeKnowledges,
+                            shapeValueKnowledges);
+      if (shapeInterface
+              .inferReturnTypeComponents(op->getContext(), op->getLoc(), range,
+                                         op->getAttrDictionary(),
+                                         op->getPropertiesStorage(),
+                                         op->getRegions(), results)
+              .succeeded()) {
+        return success();
+      }
+    }
+
+    if (auto typeInterface = dyn_cast<InferTypeOpInterface>(op)) {
+      shape_analysis::ValueTypeModificatoinRAII valueTypeModification;
+      for (auto &&operand : op->getOperands()) {
+        if (auto shape = shapeKnowledges(operand)) {
+          valueTypeModification.Push(operand, shape);
+        }
+      }
+      llvm::SmallVector<Type> inferredType;
+      if (typeInterface
+              .inferReturnTypes(op->getContext(), op->getLoc(),
+                                op->getOperands(), op->getAttrDictionary(),
+                                op->getPropertiesStorage(), op->getRegions(),
+                                inferredType)
+              .succeeded()) {
+        results.assign(llvm::to_vector(llvm::map_range(
+            inferredType, [](mlir::Type t) -> ShapedTypeComponents {
+              if (auto st = dyn_cast_or_null<ShapedType>(t))
+                return st;
+              return {};
+            })));
+        return success();
+      }
+    }
+
+    return failure();
+  }
+};
+
 // derived from SCP but override for some operation which could be folded with
 // operand type instead of operand value, for such operation it should not mark
 // them as pessimistic fixpoint when fold failed with given operand value, it
 // might be updated once operand type is inferred
+template <typename ShapeKnowledgeType>
 class ShapeValueAnalysis : public dataflow::SparseConstantPropagation {
 public:
-  using SparseConstantPropagation::SparseConstantPropagation;
+  using dataflow::SparseConstantPropagation::SparseConstantPropagation;
+  using ShapeLattice = dataflow::Lattice<ShapeKnowledgeType>;
 
   void visitOperation(Operation *op,
                       ArrayRef<const ShapeValueLattice *> operands,
-                      ArrayRef<ShapeValueLattice *> results) override;
+                      ArrayRef<ShapeValueLattice *> results) override {
+    LLVM_DEBUG(llvm::dbgs() << "shape value analysis on " << *op << "\n");
+    TypeSwitch<Operation *>(op)
+        .template Case<shape::ShapeOfOp>([&](Operation *op) {
+          auto *shapeLattice = getOrCreate<ShapeLattice>(op->getOperand(0));
+          shapeLattice->useDefSubscribe(this);
+          if (shapeLattice->getValue().isUninitialized()) {
+            return;
+          }
+          auto inputType =
+              dyn_cast<RankedTensorType>(shapeLattice->getValue().getType());
+          if (!inputType || !inputType.hasStaticShape()) {
+            return setAllToEntryStates(results);
+          }
+          auto shape = inputType.getShape();
+          auto outType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+          auto resultAttr = DenseIntElementsAttr::get(outType, shape);
+          auto lattice = results[0];
+          propagateIfChanged(lattice, lattice->join(dataflow::ConstantValue(
+                                          resultAttr, op->getDialect())));
+        })
+        .template Case<tensor::DimOp>([&](Operation *op) {
+          SmallVector<const ShapeLattice *> shapeLattices(op->getNumOperands(),
+                                                          nullptr);
+          shapeLattices[0] = getOrCreate<ShapeLattice>(op->getOperand(0));
+          visitOperation(op, operands, shapeLattices, results);
+        })
+        .template Case<arith::IndexCastOp>([&](Operation *op) {
+          const ShapeValueLattice *index = operands[0];
+          if (index->getValue().isUninitialized()) {
+            return;
+          }
+          Attribute constAttr = index->getValue().getConstantValue();
+          if (auto denseInt =
+                  dyn_cast_or_null<DenseIntElementsAttr>(constAttr)) {
+
+            auto newType = denseInt.getType().clone(
+                cast<RankedTensorType>(cast<arith::IndexCastOp>(op).getType())
+                    .getElementType());
+
+            SmallVector<APInt> newDenseInt;
+            uint32_t width;
+            auto elemType = newType.getElementType();
+            if (elemType.isIntOrFloat()) {
+              width = elemType.getIntOrFloatBitWidth();
+            } else {
+              assert(isa<IndexType>(elemType));
+              width = IndexType::kInternalStorageBitWidth;
+            }
+
+            for (auto i : denseInt.getValues<APInt>()) {
+              newDenseInt.push_back(APInt(width, i.getZExtValue()));
+            }
+
+            auto resultAttr = DenseElementsAttr::get(newType, newDenseInt);
+
+            auto lattice = results[0];
+            propagateIfChanged(lattice, lattice->join(dataflow::ConstantValue(
+                                            resultAttr, op->getDialect())));
+
+          } else {
+            dataflow::SparseConstantPropagation::visitOperation(op, operands,
+                                                                results);
+          }
+        })
+        .template Default([&](Operation *op) {
+          dataflow::SparseConstantPropagation::visitOperation(op, operands,
+                                                              results);
+        });
+  }
 
 protected:
   // very similar to SparseConstantPropagation but fold \p op with given
@@ -216,20 +410,34 @@ protected:
   virtual void visitOperation(Operation *op,
                               ArrayRef<const ShapeValueLattice *> operands,
                               ArrayRef<const ShapeLattice *> ShapeLattices,
-                              ArrayRef<ShapeValueLattice *> results);
+                              ArrayRef<ShapeValueLattice *> results) {
+    shape_analysis::ValueTypeModificatoinRAII valueTypeModification;
+
+    bool missingShape = false;
+    for (auto &&pi : zip(op->getOperands(), ShapeLattices)) {
+      auto shapeLattice = std::get<1>(pi);
+      if (shapeLattice) {
+        const_cast<ShapeLattice *>(shapeLattice)->useDefSubscribe(this);
+
+        if (!shapeLattice->getValue().isUninitialized()) {
+          auto shapeKnowledge = shapeLattice->getValue();
+          if (shapeKnowledge && shapeKnowledge.dtype) {
+            valueTypeModification.Push(std::get<0>(pi),
+                                       shapeKnowledge.getType());
+            continue;
+          }
+        } else {
+          missingShape = true;
+        }
+      }
+    }
+    if (missingShape)
+      return;
+
+    dataflow::SparseConstantPropagation::visitOperation(op, operands, results);
+  }
 };
-
-using BoundedValueLattice =
-    dataflow::Lattice<value_analysis::BoundedValueKnowledge>;
-
-class BoundedValueAnalysis
-    : public dataflow::SparseForwardDataFlowAnalysis<BoundedValueLattice> {
-public:
-  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
-
-  void setToEntryState(BoundedValueLattice *lattice) override;
-};
-
 } // namespace mlir
+#undef DEBUG_TYPE
 
 #endif // BYTEIR_ANALYSIS_SHAPEANALYSIS_H

--- a/compiler/include/byteir/Dialect/Shape/IR/ShapeExtBase.td
+++ b/compiler/include/byteir/Dialect/Shape/IR/ShapeExtBase.td
@@ -26,7 +26,7 @@ def ShapeExtDialect : Dialect {
   let summary = "Extension for shape dialect";
 
   let cppNamespace = "::mlir::shape_ext";
-  let dependentDialects = ["arith::ArithDialect", "tensor::TensorDialect", "shape::ShapeDialect"];
+  let dependentDialects = ["arith::ArithDialect", "tensor::TensorDialect", "shape::ShapeDialect", "scf::SCFDialect"];
 
   // let useDefaultTypePrinterParser = 1;
   // let hasConstantMaterializer = 1;

--- a/compiler/include/byteir/Dialect/Shape/Passes.td
+++ b/compiler/include/byteir/Dialect/Shape/Passes.td
@@ -44,6 +44,7 @@ def InsertTieShape : Pass<"insert-tie-shape", "mlir::func::FuncOp"> {
   }];
   let constructor = "mlir::createInsertTieShapePass()";
   let dependentDialects = [
+    "mlir::mhlo::MhloDialect",
     "mlir::shape_ext::ShapeExtDialect",
     "mlir::tensor::TensorDialect",
   ];

--- a/compiler/include/byteir/Dialect/mhlo/Analysis/ShapeAnalysis.h
+++ b/compiler/include/byteir/Dialect/mhlo/Analysis/ShapeAnalysis.h
@@ -19,33 +19,139 @@
 #define BYTEIR_DIALECT_MHLO_ANALYSIS_SHAPEANALYSIS_H
 
 #include "byteir/Analysis/ShapeAnalysis.h"
+#include "byteir/Dialect/mhlo/Util/ShapeInferUtil.h"
+#include "byteir/Utils/Utils.h"
+#include "mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include <cassert>
+
+#define DEBUG_TYPE "mhlo-shape-analysis"
+#define K_INITIAL -999
 
 namespace mlir {
+namespace value_analysis {
+struct BoundedValueKnowledge {
+  struct BoundedValue {
+    Attribute lower;
+    Attribute upper;
+    bool operator==(const BoundedValue &rhs) const {
+      return lower == rhs.lower && upper == rhs.upper;
+    }
+    bool isUnknwon() const { return (!lower) || (!upper); }
+  };
+  explicit BoundedValueKnowledge() = default;
+  explicit BoundedValueKnowledge(BoundedValue bdValue)
+      : boundedValue(bdValue) {}
+  explicit BoundedValueKnowledge(Attribute lower, Attribute upper) {
+    BoundedValue bv;
+    bv.lower = lower;
+    bv.upper = upper;
+    boundedValue = bv;
+  }
 
-class MhloShapeAnalysis : public ShapeAnalysis {
+  // Get the static knowledge intrinsic to `type`.
+  static BoundedValueKnowledge getUninitializedValue();
+
+  static BoundedValueKnowledge getUnknownValue();
+
+  static BoundedValueKnowledge getKnownValue(Attribute lower, Attribute upper);
+
+  static BoundedValueKnowledge join(const BoundedValueKnowledge &lhs,
+                                    const BoundedValueKnowledge &rhs);
+
+  static BoundedValueKnowledge meet(const BoundedValueKnowledge &lhs,
+                                    const BoundedValueKnowledge &rhs);
+
+  /// Whether the state is uninitialized.
+  bool isUninitialized() const { return !boundedValue.has_value(); }
+
+  bool isUnknown() const {
+    return boundedValue.has_value() && boundedValue->isUnknwon();
+  }
+
+  bool isKnown() const {
+    return boundedValue.has_value() && !boundedValue->isUnknwon();
+  }
+
+  bool operator==(const BoundedValueKnowledge &rhs) const {
+    return boundedValue == rhs.boundedValue;
+  }
+
+  Attribute lower() const;
+  Attribute upper() const;
+
+  void print(raw_ostream &os) const;
+
+  std::optional<BoundedValue> boundedValue;
+};
+} // namespace value_analysis
+
+using BoundedValueLattice =
+    dataflow::Lattice<value_analysis::BoundedValueKnowledge>;
+
+template <typename ShapeKnowledgeType>
+class MhloShapeAnalysisBase : public ShapeAnalysis<ShapeKnowledgeType> {
 public:
-  using ShapeAnalysis::ShapeAnalysis;
+  using ShapeAnalysis<ShapeKnowledgeType>::ShapeAnalysis;
+  using ShapeLattice = typename ShapeAnalysis<ShapeKnowledgeType>::ShapeLattice;
 
   LogicalResult inferResultShapesWithKnowledges(
       Operation *op, ShapeKnowledges shapeKnowledges,
       ShapeValueKnowledges shapeValueKnowledges,
-      llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results) override;
+      llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results) override {
+    InferReturnTypeComponents inferFunc = nullptr;
+    if (auto customCall = dyn_cast<mhlo::CustomCallOp>(op)) {
+      inferFunc = inferReturnTypeComponents(customCall.getCallTargetName());
+    } else {
+      inferFunc = inferReturnTypeComponents(op->getName().getStringRef());
+    }
+    if (nullptr == inferFunc) {
+      // fallback to generic shape analysis
+      return ShapeAnalysis<ShapeKnowledgeType>::inferResultShapesWithKnowledges(
+          op, shapeKnowledges, shapeValueKnowledges, results);
+    }
+    shape_analysis::ValueTypeModificatoinRAII valueTypeModification;
+    for (auto &&operand : op->getOperands()) {
+      Type newType = operand.getType();
+      if (auto shape = shapeKnowledges(operand)) {
+        newType = shape;
+      }
+      if (newType != operand.getType()) {
+        valueTypeModification.Push(operand, newType);
+      }
+    }
+
+    //  if return Attr{nullptr}, Type{nullptr} directly, ShapeAdaptor would try
+    //  dync_cast<> which cause crash
+    auto wrapperShapeKnowledges = [&](Value v) -> ShapeAdaptor {
+      if (auto type = shapeKnowledges(v)) {
+        return type;
+      }
+      return nullptr;
+    };
+    auto wrapperShapeValueKnowledges = [&](Value v) -> ShapeAdaptor {
+      if (auto attr = shapeValueKnowledges(v)) {
+        return attr;
+      }
+      return nullptr;
+    };
+    ValueShapeRange range(op->getOperands(), wrapperShapeKnowledges,
+                          wrapperShapeValueKnowledges);
+
+    return inferFunc(op->getContext(), op->getLoc(), range,
+                     op->getAttrDictionary(), op->getRegions(), results);
+  }
 };
 
-class MhloShapeValueAnalysis : public ShapeValueAnalysis {
+class MhloBoundedShapeAnalysis
+    : public MhloShapeAnalysisBase<shape_analysis::BoundedShapeKnowledge> {
 public:
-  using ShapeValueAnalysis::ShapeValueAnalysis;
-
-  // in consistent with ShapeValueAnalysis, add customized handle logic for
-  // ops in mhlo dialect
-  void visitOperation(Operation *op,
-                      ArrayRef<const ShapeValueLattice *> operands,
-                      ArrayRef<ShapeValueLattice *> results) override;
-};
-
-class MhloBoundedShapeAnalysis : public MhloShapeAnalysis {
-public:
-  using MhloShapeAnalysis::MhloShapeAnalysis;
+  using MhloShapeAnalysisBase::MhloShapeAnalysisBase;
+  using ShapeLattice = dataflow::Lattice<shape_analysis::BoundedShapeKnowledge>;
 
   void visitOperation(Operation *op, ArrayRef<const ShapeLattice *> operands,
                       ArrayRef<ShapeLattice *> results) override;
@@ -55,10 +161,348 @@ public:
       llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results) override;
 };
 
-class MhloBoundedValueAnalysis : public BoundedValueAnalysis {
-public:
-  using BoundedValueAnalysis::BoundedValueAnalysis;
+bool getFloat(Type eleType, float val, APFloat &value);
 
+template <typename T>
+DenseElementsAttr PadOpFold(DenseElementsAttr input, T padValue,
+                            RankedTensorType returnType,
+                            DenseIntElementsAttr edgePaddingLow,
+                            DenseIntElementsAttr edgePaddingHigh,
+                            DenseIntElementsAttr interiorPadding) {
+  if (!input.getType().hasStaticShape() ||
+      !edgePaddingLow.getType().hasStaticShape() ||
+      !edgePaddingHigh.getType().hasStaticShape()) {
+    return {};
+  }
+  if (interiorPadding && !interiorPadding.getType().hasStaticShape())
+    return {};
+  // Fill the full result tensor with the padding value.
+  llvm::SmallVector<T> result(returnType.getNumElements(), padValue);
+
+  auto nextIndex = [](llvm::SmallVector<uint64_t> &index,
+                      llvm::ArrayRef<int64_t> shape) {
+    for (int64_t i = index.size() - 1; i >= 0; --i) {
+      ++index[i];
+      if (static_cast<int64_t>(index[i]) < shape[i])
+        return;
+      index[i] = 0;
+    }
+  };
+
+  // Iterate over all elements of the input tensor and copy it to the correct
+  // location in the output tensor.
+  llvm::SmallVector<uint64_t> index(input.getType().getRank(), 0);
+  uint64_t numElements = input.getNumElements();
+  for (uint64_t operandIdx = 0; operandIdx < numElements; operandIdx++) {
+    bool valid = true;
+    for (int i = 0; i < input.getType().getRank(); ++i) {
+      int64_t lowPad = edgePaddingLow.getValues<int64_t>()[i];
+      int64_t highPad = edgePaddingHigh.getValues<int64_t>()[i];
+      int64_t dim = input.getType().getShape()[i];
+      int64_t start = -std::min((int64_t)0, lowPad);
+      int64_t end = dim + std::min((int64_t)0, highPad);
+      if (static_cast<int64_t>(index[i]) < start ||
+          static_cast<int64_t>(index[i]) >= end) {
+        valid = false;
+        break;
+      }
+    }
+    if (!valid) {
+      nextIndex(index, input.getType().getShape());
+      continue;
+    }
+    uint64_t resultIdx = 0;
+    uint64_t idxMultiplyer = 1;
+    for (int64_t i = index.size() - 1; i >= 0; --i) {
+      int64_t interiorPaddingValue =
+          (interiorPadding) ? interiorPadding.getValues<int64_t>()[i] : 0;
+      resultIdx += (edgePaddingLow.getValues<int64_t>()[i] +
+                    index[i] * (interiorPaddingValue + 1)) *
+                   idxMultiplyer;
+      idxMultiplyer *= returnType.getDimSize(i);
+    }
+    auto value = input.getValues<T>()[operandIdx];
+    result[resultIdx] = value;
+    nextIndex(index, input.getType().getShape());
+  }
+  return DenseElementsAttr::get(returnType, result);
+}
+
+template <class T, class F = T(T, T)>
+DenseElementsAttr
+ReduceWindowOpFold(DenseElementsAttr inputAttr, RankedTensorType outputType,
+                   ArrayRef<int64_t> dimensions, ArrayRef<int64_t> strides,
+                   T &initValue, F &functor) {
+  auto inputShape = inputAttr.getType().getShape();
+  auto outputShape = outputType.getShape();
+  llvm::SmallVector<T> output(outputType.getNumElements(), initValue);
+  auto values = inputAttr.getValues<T>();
+  auto tensorIndexToScalarIndex = [](ArrayRef<uint64_t> index,
+                                     ArrayRef<int64_t> shape) {
+    assert(shape.size() == index.size());
+    uint64_t resultIdx = 0;
+    uint64_t idxMultiplyer = 1;
+    for (int i = index.size() - 1; i >= 0; --i) {
+      resultIdx += index[i] * idxMultiplyer;
+      idxMultiplyer *= shape[i];
+    }
+    return resultIdx;
+  };
+  auto nextIndex =
+      [](llvm::SmallVector<uint64_t> &index, llvm::ArrayRef<int64_t> windowDims,
+         llvm::ArrayRef<int64_t> windowStrides, llvm::ArrayRef<int64_t> shape) {
+        for (int64_t i = index.size() - 1; i >= 0; --i) {
+          index[i] += windowStrides[i];
+          if (static_cast<int64_t>(index[i] + windowDims[i]) < shape[i])
+            return;
+          index[i] = 0;
+        }
+      };
+  auto nextKernelIndex = [](llvm::SmallVector<uint64_t> &startIndex,
+                            llvm::ArrayRef<int64_t> windowDims,
+                            llvm::SmallVector<uint64_t> &index) {
+    for (int64_t i = index.size() - 1; i >= 0; --i) {
+      ++index[i];
+      if (static_cast<int64_t>(index[i]) <
+          (static_cast<int64_t>(startIndex[i]) + windowDims[i]))
+        return;
+      index[i] = startIndex[i];
+    }
+  };
+  uint64_t kernelNums = 1;
+  for (auto dim : dimensions) {
+    kernelNums *= dim;
+  }
+
+  llvm::SmallVector<uint64_t> startIndex(inputShape.size(), 0);
+  for (uint64_t i = 0; i < output.size(); ++i) {
+    llvm::SmallVector<uint64_t> index = startIndex;
+    T &value = output[i];
+    for (uint64_t j = 0; j < kernelNums; ++j) {
+      uint64_t scalerIndex = tensorIndexToScalarIndex(index, inputShape);
+      value = functor(value, values[scalerIndex]);
+      nextKernelIndex(startIndex, dimensions, index);
+    }
+    nextIndex(startIndex, dimensions, strides, inputShape);
+  }
+  DenseElementsAttr outputAttr = DenseElementsAttr::get(outputType, output);
+  return outputAttr;
+}
+
+template <class T, class F = T(T, T)>
+DenseElementsAttr Maximum(DenseElementsAttr lhsAttr, DenseElementsAttr rhsAttr,
+                          F &functor) {
+  if (!lhsAttr || !rhsAttr)
+    return {};
+  auto lhsValues = lhsAttr.getValues<T>();
+  auto rhsValues = rhsAttr.getValues<T>();
+  assert(lhsValues.size() == rhsValues.size());
+  llvm::SmallVector<T> output;
+  output.reserve(lhsValues.size());
+  for (uint64_t i = 0; i < lhsValues.size(); ++i) {
+    output.push_back(functor(lhsValues[i], rhsValues[i]));
+  }
+  DenseElementsAttr outputAttr =
+      DenseElementsAttr::get(lhsAttr.getType(), output);
+  return outputAttr;
+}
+
+template <typename ShapeKnowledgeType>
+class MhloShapeValueAnalysisBase
+    : public ShapeValueAnalysis<ShapeKnowledgeType> {
+public:
+  using ShapeValueAnalysis<ShapeKnowledgeType>::ShapeValueAnalysis;
+  using ShapeLattice =
+      typename ShapeValueAnalysis<ShapeKnowledgeType>::ShapeLattice;
+
+  // in consistent with ShapeValueAnalysis, add customized handle logic for
+  // ops in mhlo dialect
+  void visitOperation(Operation *op,
+                      ArrayRef<const ShapeValueLattice *> operands,
+                      ArrayRef<ShapeValueLattice *> results) override {
+    LLVM_DEBUG(llvm::dbgs() << "mhlo shape value analysis on " << *op << "\n");
+    TypeSwitch<Operation *>(op)
+        .Case<mhlo::ReduceOp>([&](Operation *op) {
+          mhlo::ReduceOp reduceOp = dyn_cast<mhlo::ReduceOp>(op);
+          auto num = op->getNumResults();
+          assert(num == 1);
+          Operation &innerOp = *reduceOp.getBody().front().begin();
+          if (!dyn_cast<mhlo::MulOp>(&innerOp)) {
+            return this->template setAllToEntryStates(results);
+          }
+          Value input = reduceOp.getInputs()[0];
+          Value output = op->getResult(0);
+
+          auto *operand = operands[0];
+          auto *inputShapeLattice =
+              this->template getOrCreate<ShapeLattice>(input);
+          inputShapeLattice->useDefSubscribe(this);
+          auto *outputShapeLattice =
+              this->template getOrCreate<ShapeLattice>(output);
+          outputShapeLattice->useDefSubscribe(this);
+
+          if (operand->getValue().isUninitialized()) {
+            return;
+          }
+          if (inputShapeLattice->getValue().isUninitialized()) {
+            return;
+          }
+          if (outputShapeLattice->getValue().isUninitialized()) {
+            return;
+          }
+
+          if (!operand->getValue().getConstantValue()) {
+            return this->template setAllToEntryStates(results);
+          }
+          RankedTensorType inputType = dyn_cast<RankedTensorType>(
+              inputShapeLattice->getValue().getType());
+          if (!inputType || !inputType.hasStaticShape()) {
+            return this->template setAllToEntryStates(results);
+          }
+          RankedTensorType outputType = dyn_cast<RankedTensorType>(
+              outputShapeLattice->getValue().getType());
+          if (!outputType || !outputType.hasStaticShape()) {
+            return this->template setAllToEntryStates(results);
+          }
+
+          auto inputShape = inputType.getShape();
+          auto dimensions = reduceOp.getDimensions().getValues<int64_t>();
+          llvm::SmallVector<int64_t> windowDimensions(inputShape.size(), 1);
+          for (auto dim : dimensions) {
+            windowDimensions[dim] = inputShape[dim];
+          }
+          llvm::SmallVector<int64_t> windowStrides(inputShape.size(), 1);
+          DenseElementsAttr inputAttr = dyn_cast<DenseElementsAttr>(
+              operand->getValue().getConstantValue());
+
+          Attribute outAttr;
+          if (isa<FloatType>(outputType.getElementType())) {
+            APFloat initValue(cast<FloatType>(outputType.getElementType())
+                                  .getFloatSemantics());
+            assert(getFloat(outputType.getElementType(), 1.0, initValue));
+            std::function<APFloat(APFloat, APFloat)> mulFunctor =
+                [](APFloat l, APFloat r) { return l * r; };
+            outAttr =
+                ReduceWindowOpFold(inputAttr, outputType, windowDimensions,
+                                   windowStrides, initValue, mulFunctor);
+          } else if (isa<IntegerType>(outputType.getElementType())) {
+            APInt initValue(inputAttr.getValues<APInt>()[0].getBitWidth(), 1);
+            std::function<APInt(APInt, APInt)> mulFunctor =
+                [](APInt l, APInt r) { return l * r; };
+            outAttr =
+                ReduceWindowOpFold(inputAttr, outputType, windowDimensions,
+                                   windowStrides, initValue, mulFunctor);
+          } else {
+            return dataflow::SparseConstantPropagation::visitOperation(
+                op, operands, results);
+          }
+
+          auto lattice = results[0];
+          this->template propagateIfChanged(
+              lattice, lattice->join(mlir::dataflow::ConstantValue(
+                           outAttr, op->getDialect())));
+        })
+        .template Case<mhlo::ComputeReshapeShapeOp>([&](Operation *op) {
+          mhlo::ComputeReshapeShapeOp computeReshapeShapeOp =
+              dyn_cast<mhlo::ComputeReshapeShapeOp>(op);
+          Value dynamicShapeV = computeReshapeShapeOp.getDynamicShape();
+          auto *boundedShapeValue =
+              this->template getOrCreate<BoundedValueLattice>(dynamicShapeV);
+          boundedShapeValue->useDefSubscribe(this);
+
+          const ShapeValueLattice *product = operands[0];
+          const ShapeValueLattice *shapeValue = operands[1];
+          if (product->getValue().isUninitialized()) {
+            return;
+          }
+          if (shapeValue->getValue().isUninitialized()) {
+            return;
+          }
+          if (boundedShapeValue->getValue().isUninitialized()) {
+            return;
+          }
+
+          if (!product->getValue().getConstantValue()) {
+            return this->template setAllToEntryStates(results);
+          }
+          if (!shapeValue->getValue().getConstantValue() &&
+              boundedShapeValue->getValue().isUnknown()) {
+            return this->template setAllToEntryStates(results);
+          }
+          Attribute productAttr = product->getValue().getConstantValue();
+          Attribute constShapeAttr = shapeValue->getValue().getConstantValue();
+          Attribute upperShapeAttr = boundedShapeValue->getValue().upper();
+          if (constShapeAttr) {
+            assert(!upperShapeAttr);
+          } else {
+            assert(upperShapeAttr);
+            constShapeAttr = upperShapeAttr;
+          }
+
+          Attribute resAttr = constShapeAttr;
+          ShapeValueLattice *lattice = results[0];
+          // in some cases, the shape in computeReshapeShapeOp is dense<[-1, x,
+          // ....]>, we need calculate firstly
+          do {
+            auto denseInt =
+                dyn_cast_or_null<DenseIntElementsAttr>(constShapeAttr);
+            if (denseInt == nullptr) {
+              break;
+            }
+            auto dataType = dyn_cast<IntegerType>(denseInt.getElementType());
+            // is int32
+            if (dataType == nullptr || dataType.isUnsigned() ||
+                dataType.getWidth() != 32) {
+              break;
+            }
+            llvm::SmallVector<int32_t> shape =
+                llvm::to_vector(denseInt.getValues<int32_t>());
+
+            // check whether has dimSize < 0, aka dynamic in mhlo
+            int cntDynamic = llvm::count_if(
+                shape, [](int32_t dimSize) { return dimSize < 0; });
+
+            if (cntDynamic == 1) {
+              if (auto num = dyn_cast_or_null<IntegerAttr>(productAttr)) {
+                int64_t number = num.getInt();
+                if (number < 0) {
+                  break;
+                }
+
+                int32_t index = K_INITIAL;
+                for (auto elem : llvm::enumerate(shape)) {
+                  if (elem.value() < 0) {
+                    index = elem.index();
+                  } else {
+                    number /= elem.value();
+                  }
+                }
+                assert(index != K_INITIAL);
+                shape[index] = number;
+                resAttr = DenseIntElementsAttr::get(denseInt.getType(), shape);
+              }
+            }
+          } while (0);
+
+          LLVM_DEBUG(llvm::dbgs() << "Folded to constant: " << resAttr << "\n");
+          this->template propagateIfChanged(
+              lattice, lattice->join(mlir::dataflow::ConstantValue(
+                           resAttr, op->getDialect())));
+        })
+        .Default([&](Operation *op) {
+          ShapeValueAnalysis<ShapeKnowledgeType>::visitOperation(op, operands,
+                                                                 results);
+        });
+  }
+};
+
+class MhloBoundedValueAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<BoundedValueLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  using ShapeLattice = dataflow::Lattice<shape_analysis::BoundedShapeKnowledge>;
+
+  void setToEntryState(BoundedValueLattice *lattice) override;
   void visitOperation(Operation *op,
                       ArrayRef<const BoundedValueLattice *> operands,
                       ArrayRef<BoundedValueLattice *> results) override;
@@ -66,7 +510,6 @@ public:
 protected:
   void visitOperation(Operation *op,
                       ArrayRef<const BoundedValueLattice *> operands,
-                      // ArrayRef<ShapeLattice *> shapeLattices,
                       ArrayRef<ShapeValueLattice *> shapeValueLattices,
                       ArrayRef<BoundedValueLattice *> results);
   void foldOp(Operation *op, ArrayRef<Attribute> lowerAttrs,
@@ -74,6 +517,17 @@ protected:
               ArrayRef<BoundedValueLattice *> results);
 };
 
+using StaticShapeLattice =
+    dataflow::Lattice<shape_analysis::StaticShapeKnowledge>;
+using BoundedShapeLattice =
+    dataflow::Lattice<shape_analysis::BoundedShapeKnowledge>;
+using MhloStaticShapeAnalysis =
+    MhloShapeAnalysisBase<shape_analysis::StaticShapeKnowledge>;
+using MhloStaticShapeValueAnalysis =
+    MhloShapeValueAnalysisBase<shape_analysis::StaticShapeKnowledge>;
+using MhloBoundedShapeValueAnalysis =
+    MhloShapeValueAnalysisBase<shape_analysis::BoundedShapeKnowledge>;
 } // namespace mlir
+#undef DEBUG_TYPE
 
 #endif // BYTEIR_DIALECT_MHLO_ANALYSIS_SHAPEANALYSIS_H

--- a/compiler/include/byteir/Dialect/mhlo/Passes.td
+++ b/compiler/include/byteir/Dialect/mhlo/Passes.td
@@ -34,6 +34,9 @@ def BoundedShapeInference : Pass<"bounded-shape-infer", "func::FuncOp"> {
     and reuse the static operations' shape inference implementation. 
   }];
   let constructor = "mlir::createBoundedShapeInferencePass()";
+  let dependentDialects = [
+    "mlir::scf::SCFDialect"
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/lib/Analysis/ShapeAnalysis.cpp
+++ b/compiler/lib/Analysis/ShapeAnalysis.cpp
@@ -16,14 +16,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "byteir/Analysis/ShapeAnalysis.h"
-#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Shape/IR/Shape.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
-
-#define DEBUG_TYPE "shape-analysis"
 
 using namespace mlir::dataflow;
 using namespace mlir::shape_analysis;
@@ -31,8 +23,8 @@ using namespace mlir::shape_analysis;
 namespace mlir {
 namespace shape_analysis {
 
-ValueKnowledge ValueKnowledge::getKnowledgeFromType(Type type) {
-  ValueKnowledge result = getPessimisticValueState();
+StaticShapeKnowledge StaticShapeKnowledge::getKnowledgeFromType(Type type) {
+  StaticShapeKnowledge result = getPessimisticValueState();
   if (auto shapedType = dyn_cast_or_null<ShapedType>(type)) {
     if (shapedType.hasRank()) {
       result.hasRank = true;
@@ -45,20 +37,22 @@ ValueKnowledge ValueKnowledge::getKnowledgeFromType(Type type) {
   return result;
 }
 
-ValueKnowledge ValueKnowledge::getPessimisticValueState() {
-  return ValueKnowledge(false, {}, Type());
+StaticShapeKnowledge StaticShapeKnowledge::getPessimisticValueState() {
+  return StaticShapeKnowledge(false, {}, Type());
 }
 
-ValueKnowledge ValueKnowledge::getPessimisticValueState(Value value) {
+StaticShapeKnowledge
+StaticShapeKnowledge::getPessimisticValueState(Value value) {
   if (value) {
     return getKnowledgeFromType(value.getType());
   }
   return getPessimisticValueState();
 }
 
-ValueKnowledge ValueKnowledge::join(const ValueKnowledge &lhs,
-                                    const ValueKnowledge &rhs) {
-  ValueKnowledge result = getPessimisticValueState();
+StaticShapeKnowledge
+StaticShapeKnowledge::join(const StaticShapeKnowledge &lhs,
+                           const StaticShapeKnowledge &rhs) {
+  StaticShapeKnowledge result = getPessimisticValueState();
   result.hasError = true;
 
   // if ((lhs.dtype.has_value() && !lhs.dtype.value()) ||
@@ -99,9 +93,10 @@ ValueKnowledge ValueKnowledge::join(const ValueKnowledge &lhs,
   return result;
 }
 
-ValueKnowledge ValueKnowledge::meet(const ValueKnowledge &lhs,
-                                    const ValueKnowledge &rhs) {
-  ValueKnowledge result = getPessimisticValueState();
+StaticShapeKnowledge
+StaticShapeKnowledge::meet(const StaticShapeKnowledge &lhs,
+                           const StaticShapeKnowledge &rhs) {
+  StaticShapeKnowledge result = getPessimisticValueState();
   result.hasError = true;
 
   // if ((lhs.dtype.has_value() && !lhs.dtype.value()) ||
@@ -159,7 +154,7 @@ ValueKnowledge ValueKnowledge::meet(const ValueKnowledge &lhs,
   return result;
 }
 
-void ValueKnowledge::print(raw_ostream &os) const {
+void StaticShapeKnowledge::print(raw_ostream &os) const {
   if (hasError || !dtype) {
     os << "None\n";
   } else if (!(*dtype)) {
@@ -168,363 +163,135 @@ void ValueKnowledge::print(raw_ostream &os) const {
     os << getType() << "\n";
   }
 }
+
+BoundedShapeKnowledge BoundedShapeKnowledge::getKnowledgeFromType(Type type) {
+  BoundedShapeKnowledge result = getPessimisticValueState();
+  if (auto shapedType = dyn_cast_or_null<ShapedType>(type)) {
+    if (shapedType.hasRank()) {
+      result.hasRank = true;
+      result.sizes.reserve(shapedType.getRank());
+      for (auto dim : shapedType.getShape())
+        result.sizes.push_back(dim);
+    }
+    result.dtype = shapedType.getElementType();
+  }
+  return result;
+}
+
+BoundedShapeKnowledge BoundedShapeKnowledge::getPessimisticValueState() {
+  return BoundedShapeKnowledge(false, {}, Type());
+}
+
+BoundedShapeKnowledge
+BoundedShapeKnowledge::getPessimisticValueState(Value value) {
+  if (value) {
+    return getKnowledgeFromType(value.getType());
+  }
+  return getPessimisticValueState();
+}
+
+BoundedShapeKnowledge
+BoundedShapeKnowledge::join(const BoundedShapeKnowledge &lhs,
+                            const BoundedShapeKnowledge &rhs) {
+  BoundedShapeKnowledge result = getPessimisticValueState();
+  result.hasError = true;
+
+  if (lhs.isUninitialized())
+    return rhs;
+  if (rhs.isUninitialized())
+    return lhs;
+  // Early termination when dtype is nullptr
+  // or not identical
+  if (!(*lhs.dtype) || !(*rhs.dtype) || *lhs.dtype != *rhs.dtype)
+    return result;
+
+  result.hasError = false;
+  result.dtype = lhs.dtype;
+
+  if (!lhs.hasRank || !rhs.hasRank) {
+    result.hasRank = false;
+    return result;
+  }
+
+  if (lhs.sizes.size() != rhs.sizes.size()) {
+    result.hasRank = false;
+    return result;
+  }
+
+  result.hasRank = true;
+  result.sizes.resize(lhs.sizes.size(), ShapedType::kDynamic);
+  for (int i = 0, e = lhs.sizes.size(); i < e; i++) {
+    if (lhs.sizes[i] == rhs.sizes[i]) {
+      result.sizes[i] = lhs.sizes[i];
+    } else if (lhs.sizes[i] != ShapedType::kDynamic &&
+               rhs.sizes[i] != ShapedType::kDynamic) {
+      result.sizes[i] =
+          (lhs.sizes[i] > rhs.sizes[i]) ? lhs.sizes[i] : rhs.sizes[i];
+    }
+  }
+
+  return result;
+}
+
+BoundedShapeKnowledge
+BoundedShapeKnowledge::meet(const BoundedShapeKnowledge &lhs,
+                            const BoundedShapeKnowledge &rhs) {
+  BoundedShapeKnowledge result = getPessimisticValueState();
+  result.hasError = true;
+
+  // if ((lhs.dtype.has_value() && !lhs.dtype.value()) ||
+  //     (rhs.dtype.has_value() && !rhs.dtype.value()) ||
+  //     (lhs.dtype.has_value() && rhs.dtype.has_value() &&
+  //      lhs.dtype.value() != rhs.dtype.value()))
+  //   return result;
+  if (lhs.isUninitialized())
+    return rhs;
+  if (rhs.isUninitialized())
+    return lhs;
+  // Early termination when dtype is nullptr
+  // or not identical
+  if (!(*lhs.dtype) || !(*rhs.dtype) || *lhs.dtype != *rhs.dtype)
+    return result;
+
+  result.hasError = false;
+  result.dtype = lhs.dtype;
+
+  if (!lhs.hasRank && !rhs.hasRank)
+    return result;
+
+  if (!rhs.hasRank) {
+    result.hasRank = true;
+    result.sizes = lhs.sizes;
+    return result;
+  }
+
+  if (!lhs.hasRank) {
+    result.hasRank = true;
+    result.sizes = rhs.sizes;
+    return result;
+  }
+
+  if (lhs.sizes.size() != rhs.sizes.size())
+    return result;
+
+  result.hasRank = true;
+  result.sizes.resize(lhs.sizes.size(), ShapedType::kDynamic);
+  for (auto i : llvm::seq<unsigned>(0, result.sizes.size())) {
+    int64_t lhsSize = lhs.sizes[i];
+    int64_t rhsSize = rhs.sizes[i];
+    int64_t &resultSize = result.sizes[i];
+    if (lhsSize == ShapedType::kDynamic) {
+      resultSize = rhsSize;
+    } else if (rhsSize == ShapedType::kDynamic) {
+      resultSize = lhsSize;
+    } else if (lhsSize == rhsSize) {
+      resultSize = lhsSize;
+    } else {
+      result.hasError = true;
+    }
+  }
+
+  return result;
+}
 } // namespace shape_analysis
-
-namespace value_analysis {
-BoundedValueKnowledge BoundedValueKnowledge::getUninitializedValue() {
-  return BoundedValueKnowledge();
-}
-
-BoundedValueKnowledge BoundedValueKnowledge::getUnknownValue() {
-  BoundedValue boundedValue = {Attribute(), Attribute()};
-  BoundedValueKnowledge bv;
-  bv.boundedValue = boundedValue;
-  return bv;
-}
-BoundedValueKnowledge BoundedValueKnowledge::getKnownValue(Attribute lower,
-                                                           Attribute upper) {
-  assert(lower);
-  assert(upper);
-  BoundedValue boundedValue = {lower, upper};
-  BoundedValueKnowledge bv;
-  bv.boundedValue = boundedValue;
-  return bv;
-}
-
-Attribute BoundedValueKnowledge::lower() const { return (*boundedValue).lower; }
-
-Attribute BoundedValueKnowledge::upper() const { return (*boundedValue).upper; }
-
-BoundedValueKnowledge
-BoundedValueKnowledge::join(const BoundedValueKnowledge &lhs,
-                            const BoundedValueKnowledge &rhs) {
-  if (lhs.isUninitialized())
-    return rhs;
-  if (rhs.isUninitialized())
-    return lhs;
-  if (lhs == rhs)
-    return lhs;
-  return getUnknownValue();
-}
-
-BoundedValueKnowledge
-BoundedValueKnowledge::meet(const BoundedValueKnowledge &lhs,
-                            const BoundedValueKnowledge &rhs) {
-  auto res = getUnknownValue();
-  if (lhs.isUninitialized())
-    return rhs;
-  if (rhs.isUninitialized())
-    return lhs;
-
-  if (!((*(lhs.boundedValue)).lower)) {
-    (*(res.boundedValue)).lower = (*(rhs.boundedValue)).lower;
-  } else if (!((*(rhs.boundedValue)).lower)) {
-    (*(res.boundedValue)).lower = (*(lhs.boundedValue)).lower;
-  } else if ((*(lhs.boundedValue)).lower == (*(rhs.boundedValue)).lower) {
-    (*(res.boundedValue)).lower = (*(rhs.boundedValue)).lower;
-  } else {
-    (*(res.boundedValue)).lower = Attribute();
-  }
-
-  if (!((*(lhs.boundedValue)).upper)) {
-    (*(res.boundedValue)).upper = (*(rhs.boundedValue)).upper;
-  } else if (!((*(rhs.boundedValue)).upper)) {
-    (*(res.boundedValue)).upper = (*(lhs.boundedValue)).upper;
-  } else if ((*(lhs.boundedValue)).upper == (*(rhs.boundedValue)).upper) {
-    (*(res.boundedValue)).upper = (*(rhs.boundedValue)).upper;
-  } else {
-    (*(res.boundedValue)).upper = Attribute();
-  }
-  return res;
-}
-
-void BoundedValueKnowledge::print(raw_ostream &os) const {
-  if (isUninitialized()) {
-    os << "None\n";
-  } else if (isUnknown()) {
-    if ((*boundedValue).lower) {
-      os << "lower: " << (*boundedValue).lower << "\n";
-    } else {
-      os << "lower: Unknown\n";
-    }
-    if ((*boundedValue).upper) {
-      os << "upper: " << (*boundedValue).upper << "\n";
-    } else {
-      os << "upper: Unknown\n";
-    }
-  } else {
-    os << "lower: " << (*boundedValue).lower << "\n";
-    os << "upper: " << (*boundedValue).upper << "\n";
-  }
-}
-} // namespace value_analysis
-
-LogicalResult ShapeAnalysis::inferResultShapesWithKnowledges(
-    Operation *op, ShapeKnowledges shapeKnowledges,
-    ShapeValueKnowledges shapeValueKnowledges,
-    llvm::SmallVectorImpl<::mlir::ShapedTypeComponents> &results) {
-  if (op->hasTrait<OpTrait::SameOperandsAndResultShape>()) {
-    ValueKnowledge knowledge; // uninitialized
-    for (auto &&operand : op->getOperands()) {
-      auto newKnowledge =
-          ValueKnowledge::getKnowledgeFromType(shapeKnowledges(operand));
-      newKnowledge.dtype = nullptr;
-      knowledge = ValueKnowledge::meet(knowledge, newKnowledge);
-    }
-    if (knowledge) {
-      for (auto &&resultType : op->getResultTypes()) {
-        if (auto shapedType = dyn_cast_or_null<ShapedType>(resultType)) {
-          knowledge.dtype = shapedType.getElementType();
-          results.push_back(cast<ShapedType>(knowledge.getType()));
-        } else {
-          results.push_back(ShapedTypeComponents{});
-        }
-      }
-      return success();
-    }
-  }
-
-  if (auto shapeInterface = dyn_cast<InferShapedTypeOpInterface>(op)) {
-    ValueTypeModificatoinRAII valueTypeModification;
-    for (auto &&operand : op->getOperands()) {
-      if (auto shape = shapeKnowledges(operand)) {
-        valueTypeModification.Push(operand, shape);
-      }
-    }
-    ValueShapeRange range(op->getOperands(), shapeKnowledges,
-                          shapeValueKnowledges);
-    if (shapeInterface
-            .inferReturnTypeComponents(
-                op->getContext(), op->getLoc(), range, op->getAttrDictionary(),
-                op->getPropertiesStorage(), op->getRegions(), results)
-            .succeeded()) {
-      return success();
-    }
-  }
-
-  if (auto typeInterface = dyn_cast<InferTypeOpInterface>(op)) {
-    ValueTypeModificatoinRAII valueTypeModification;
-    for (auto &&operand : op->getOperands()) {
-      if (auto shape = shapeKnowledges(operand)) {
-        valueTypeModification.Push(operand, shape);
-      }
-    }
-    llvm::SmallVector<Type> inferredType;
-    if (typeInterface
-            .inferReturnTypes(op->getContext(), op->getLoc(), op->getOperands(),
-                              op->getAttrDictionary(),
-                              op->getPropertiesStorage(), op->getRegions(),
-                              inferredType)
-            .succeeded()) {
-      results.assign(llvm::to_vector(llvm::map_range(
-          inferredType, [](mlir::Type t) -> ShapedTypeComponents {
-            if (auto st = dyn_cast_or_null<ShapedType>(t))
-              return st;
-            return {};
-          })));
-      return success();
-    }
-  }
-
-  return failure();
-}
-
-void ShapeAnalysis::visitOperation(Operation *op,
-                                   ArrayRef<const ShapeLattice *> operands,
-                                   ArrayRef<ShapeLattice *> results) {
-
-  LLVM_DEBUG(llvm::dbgs() << "shape analysis on " << *op << "\n");
-
-  llvm::DenseMap<Value, Type> shapeProvider;
-  llvm::DenseMap<Value, Attribute> valueProvider;
-  bool missingValue = false;
-  for (auto &&pi : llvm::zip(op->getOperands(), operands)) {
-    auto &&operand = std::get<0>(pi);
-    auto &&shapeLattice = std::get<1>(pi);
-    auto &&valueLattice = getOrCreate<ShapeValueLattice>(operand);
-    valueLattice->useDefSubscribe(this);
-
-    if (auto shapeKnowledge = shapeLattice->getValue()) {
-      if (shapeKnowledge.isUninitialized()) {
-        missingValue = true;
-        continue;
-      }
-    }
-
-    if (valueLattice->getValue().isUninitialized()) {
-      missingValue = true;
-      continue;
-    }
-
-    if (auto shapeKnowledge = shapeLattice->getValue()) {
-      if (*shapeKnowledge.dtype) {
-        shapeProvider[operand] = shapeKnowledge.getType();
-      }
-    }
-
-    if (valueLattice->getValue().getConstantValue()) {
-      valueProvider[operand] = valueLattice->getValue().getConstantValue();
-    }
-  }
-
-  if (missingValue) {
-    return;
-  }
-
-  auto shapeKnowledges = [&](Value val) -> Type {
-    auto it = shapeProvider.find(val);
-    if (it == shapeProvider.end())
-      return nullptr;
-    return it->second;
-  };
-  auto shapeValueKnowledges = [&](Value val) -> Attribute {
-    auto it = valueProvider.find(val);
-    if (it == valueProvider.end())
-      return nullptr;
-    return it->second;
-  };
-
-  SmallVector<ShapedTypeComponents> inferredShapes;
-  if (inferResultShapesWithKnowledges(op, shapeKnowledges, shapeValueKnowledges,
-                                      inferredShapes)
-          .succeeded()) {
-    for (auto it : llvm::zip(op->getResults(), inferredShapes, results)) {
-      Value result = std::get<0>(it);
-      ShapedTypeComponents predictedShape = std::get<1>(it);
-      ShapeLattice *resultLattice = std::get<2>(it);
-
-      Type resultTy = result.getType();
-      if (!isa<ShapedType>(resultTy)) {
-        setToEntryState(resultLattice);
-        continue;
-      }
-
-      // Compute the knowledge based on the inferred type.
-      auto inferredKnowledge = ValueKnowledge::getPessimisticValueState();
-      inferredKnowledge.dtype = cast<ShapedType>(resultTy).getElementType();
-      inferredKnowledge.hasRank = predictedShape.hasRank();
-      if (predictedShape.hasRank()) {
-        for (auto dim : predictedShape.getDims()) {
-          inferredKnowledge.sizes.push_back(dim);
-        }
-      }
-
-      propagateIfChanged(resultLattice, resultLattice->join(inferredKnowledge));
-    }
-  } else {
-    return setAllToEntryStates(results);
-  }
-}
-
-void ShapeAnalysis::setToEntryState(ShapeLattice *lattice) {
-  propagateIfChanged(
-      lattice,
-      lattice->join(shape_analysis::ValueKnowledge::getPessimisticValueState(
-          lattice->getPoint())));
-}
-
-void ShapeValueAnalysis::visitOperation(
-    Operation *op, ArrayRef<const ShapeValueLattice *> operands,
-    ArrayRef<const ShapeLattice *> ShapeLattices,
-    ArrayRef<ShapeValueLattice *> results) {
-  ValueTypeModificatoinRAII valueTypeModification;
-
-  bool missingShape = false;
-  for (auto &&pi : zip(op->getOperands(), ShapeLattices)) {
-    auto shapeLattice = std::get<1>(pi);
-    if (shapeLattice) {
-      const_cast<ShapeLattice *>(shapeLattice)->useDefSubscribe(this);
-
-      if (!shapeLattice->getValue().isUninitialized()) {
-        auto shapeKnowledge = shapeLattice->getValue();
-        if (shapeKnowledge && shapeKnowledge.dtype) {
-          valueTypeModification.Push(std::get<0>(pi), shapeKnowledge.getType());
-          continue;
-        }
-      } else {
-        missingShape = true;
-      }
-    }
-  }
-  if (missingShape)
-    return;
-
-  SparseConstantPropagation::visitOperation(op, operands, results);
-}
-
-void ShapeValueAnalysis::visitOperation(
-    Operation *op, ArrayRef<const ShapeValueLattice *> operands,
-    ArrayRef<ShapeValueLattice *> results) {
-  LLVM_DEBUG(llvm::dbgs() << "shape value analysis on " << *op << "\n");
-  TypeSwitch<Operation *>(op)
-      .Case<shape::ShapeOfOp>([&](Operation *op) {
-        auto *shapeLattice = getOrCreate<ShapeLattice>(op->getOperand(0));
-        shapeLattice->useDefSubscribe(this);
-        if (shapeLattice->getValue().isUninitialized()) {
-          return;
-        }
-        auto inputType =
-            dyn_cast<RankedTensorType>(shapeLattice->getValue().getType());
-        if (!inputType || !inputType.hasStaticShape()) {
-          return setAllToEntryStates(results);
-        }
-        auto shape = inputType.getShape();
-        auto outType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
-        auto resultAttr = DenseIntElementsAttr::get(outType, shape);
-        auto lattice = results[0];
-        propagateIfChanged(lattice, lattice->join(ConstantValue(
-                                        resultAttr, op->getDialect())));
-      })
-      .Case<tensor::DimOp>([&](Operation *op) {
-        SmallVector<const ShapeLattice *> shapeLattices(op->getNumOperands(),
-                                                        nullptr);
-        shapeLattices[0] = getOrCreate<ShapeLattice>(op->getOperand(0));
-        visitOperation(op, operands, shapeLattices, results);
-      })
-      .Case<arith::IndexCastOp>([&](Operation *op) {
-        const ShapeValueLattice *index = operands[0];
-        if (index->getValue().isUninitialized()) {
-          return;
-        }
-        Attribute constAttr = index->getValue().getConstantValue();
-        if (auto denseInt = dyn_cast_or_null<DenseIntElementsAttr>(constAttr)) {
-
-          auto newType = denseInt.getType().clone(
-              cast<RankedTensorType>(cast<arith::IndexCastOp>(op).getType())
-                  .getElementType());
-
-          SmallVector<APInt> newDenseInt;
-          uint32_t width;
-          auto elemType = newType.getElementType();
-          if (elemType.isIntOrFloat()) {
-            width = elemType.getIntOrFloatBitWidth();
-          } else {
-            assert(isa<IndexType>(elemType));
-            width = IndexType::kInternalStorageBitWidth;
-          }
-
-          for (auto i : denseInt.getValues<APInt>()) {
-            newDenseInt.push_back(APInt(width, i.getZExtValue()));
-          }
-
-          auto resultAttr = DenseElementsAttr::get(newType, newDenseInt);
-
-          auto lattice = results[0];
-          propagateIfChanged(lattice, lattice->join(ConstantValue(
-                                          resultAttr, op->getDialect())));
-
-        } else {
-          SparseConstantPropagation::visitOperation(op, operands, results);
-        }
-      })
-      .Default([&](Operation *op) {
-        SparseConstantPropagation::visitOperation(op, operands, results);
-      });
-}
-
-void BoundedValueAnalysis::setToEntryState(BoundedValueLattice *lattice) {
-  value_analysis::BoundedValueKnowledge next =
-      value_analysis::BoundedValueKnowledge::getUnknownValue();
-  propagateIfChanged(lattice, lattice->join(next));
-}
 } // namespace mlir

--- a/compiler/lib/Dialect/Shape/CMakeLists.txt
+++ b/compiler/lib/Dialect/Shape/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_dialect_library(ByteIRShapePasses
   ByteIRShapePassIncGen
   ByteIRUtils
   MLIRShapeExt
+  MhloDialect
 
   LINK_LIBS PUBLIC
   ByteIRUtils

--- a/compiler/lib/Dialect/Shape/Transforms/PassDetail.h
+++ b/compiler/lib/Dialect/Shape/Transforms/PassDetail.h
@@ -36,6 +36,10 @@ namespace shape_ext {
 class ShapeExtDialect;
 } // namespace shape_ext
 
+namespace mhlo {
+class MhloDialect;
+} // namespace mhlo
+
 #define GEN_PASS_CLASSES
 #include "byteir/Dialect/Shape/Passes.h.inc"
 

--- a/compiler/lib/Dialect/mhlo/CMakeLists.txt
+++ b/compiler/lib/Dialect/mhlo/CMakeLists.txt
@@ -116,6 +116,7 @@ add_mlir_dialect_library(ByteIRMhloPasses
   ByteIRMhloPassIncGen
   ByteIRAnalysis
   MhloDialect
+  MLIRSCFDialect
   ByteIRMhloUtils
   ByteIRUtils
   ByteIRMhloAnalysis
@@ -126,6 +127,7 @@ add_mlir_dialect_library(ByteIRMhloPasses
   LINK_LIBS PUBLIC
   MLIRIR
   MhloDialect
+  MLIRSCFDialect
   MLIRMhloUtils
   MLIRSideEffectInterfaces
   MLIRSupport

--- a/compiler/lib/Dialect/mhlo/Transforms/PassDetail.h
+++ b/compiler/lib/Dialect/mhlo/Transforms/PassDetail.h
@@ -46,6 +46,10 @@ namespace tensor {
 class TensorDialect;
 }
 
+namespace scf {
+class SCFDialect;
+}
+
 #define GEN_PASS_CLASSES
 #include "byteir/Dialect/mhlo/Passes.h.inc"
 

--- a/compiler/lib/Dialect/mhlo/Transforms/StaticShapeInference.cpp
+++ b/compiler/lib/Dialect/mhlo/Transforms/StaticShapeInference.cpp
@@ -100,8 +100,8 @@ LogicalResult mlir::runStaticShapeInfer(func::FuncOp funcOp,
     }
 
     DataFlowSolver solver;
-    solver.load<MhloShapeAnalysis>();
-    solver.load<MhloShapeValueAnalysis>();
+    solver.load<MhloStaticShapeAnalysis>();
+    solver.load<MhloStaticShapeValueAnalysis>();
     solver.load<DeadCodeAnalysis>();
     if (failed(solver.initializeAndRun(funcOp)))
       return failure();
@@ -118,7 +118,7 @@ LogicalResult mlir::runStaticShapeInfer(func::FuncOp funcOp,
           continue;
 
         ShapedType newType;
-        if (auto lattice = solver.lookupState<ShapeLattice>(it)) {
+        if (auto lattice = solver.lookupState<StaticShapeLattice>(it)) {
           if (!lattice->getValue().isUninitialized())
             newType = dyn_cast<ShapedType>(lattice->getValue().getType());
         }

--- a/compiler/lib/Transforms/CMakeLists.txt
+++ b/compiler/lib/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_mlir_library(ByteIRTransforms
   ByteIRTensorPasses
   ByteIRTransformsPassIncGen
   ByteIRUtils
+  MLIRSCFDialect
 
   LINK_LIBS PUBLIC
   ByteIRAnalysis

--- a/compiler/test/lib/Analysis/TestPrintShapeAnalysis.cpp
+++ b/compiler/test/lib/Analysis/TestPrintShapeAnalysis.cpp
@@ -44,8 +44,8 @@ struct TestPrintShapeAnalysisPass
     Operation *top = getOperation();
 
     DataFlowSolver solver;
-    solver.load<MhloShapeAnalysis>();
-    solver.load<MhloShapeValueAnalysis>();
+    solver.load<MhloStaticShapeAnalysis>();
+    solver.load<MhloStaticShapeValueAnalysis>();
     solver.load<DeadCodeAnalysis>();
     if (failed(solver.initializeAndRun(top)))
       return signalPassFailure();
@@ -54,7 +54,7 @@ struct TestPrintShapeAnalysisPass
         llvm::outs() << "for operation : " << *op
                      << ", inferred shapes are:\n\t";
         for (Value value : op->getResults()) {
-          if (auto lattice = solver.lookupState<ShapeLattice>(value)) {
+          if (auto lattice = solver.lookupState<StaticShapeLattice>(value)) {
             if (!lattice->getValue().isUninitialized()) {
               lattice->getValue().print(llvm::outs());
             }


### PR DESCRIPTION
1. support nested region such as scf.if for GraphClusteringByDevice pass
2. scf.if output type compatibility
    a. do not insert shape_ext.TieOp after a mhlo.ConvertOp when Convert static shape op to dynamic shape op
    b. set return type for thenBlock and elseBlock for scf.ifOp when the shape of the return value of scf.ifOp can be deduced
         by shape_ext.tieOp
    c. set bounded shape for thenBlock and elseBlok of scf.ifOp to meet the compatibility requirements of scf.ifop return
        types
3. decoupling static shape analysis from bounded shape analysis