### PR TITLE
[compiler] fix inf/nan convert to i32 on x86_64 arch

### DIFF
--- a/compiler/include/byteir/Conversion/Passes.td
+++ b/compiler/include/byteir/Conversion/Passes.td
@@ -63,7 +63,11 @@ def HloFusionToLinalg : Pass<"hlo-fusion-to-linalg", "func::FuncOp"> {
     Option<"enablePrimitiveOps", "enable-primitive-ops", "bool",
             /*default=*/"false",
             "Lower to primitive Linalg ops (map, reduce and "
-            "transpose) when possible, instead of linalg.generic">
+            "transpose) when possible, instead of linalg.generic">,
+    Option<"target", "target", "std::string", /*default*/ "",
+           "Specificy the target">,
+    Option<"arch", "arch", "std::string", /*default*/ "",
+           "Specificy the target arch">
   ];
 }
 

--- a/compiler/include/byteir/Conversion/ToLinalg/ToLinalg.h
+++ b/compiler/include/byteir/Conversion/ToLinalg/ToLinalg.h
@@ -41,11 +41,13 @@ void populateTensorToLinalgConversionPatterns(RewritePatternSet &patterns);
 void populateLinalgExtToLinalgConversionPatterns(RewritePatternSet &patterns);
 
 void populateHloToLinalgExtConversionPattern(TypeConverter &typeConverter,
-                                             RewritePatternSet &patterns);
+                                             RewritePatternSet &patterns,
+                                             const std::string &target = "",
+                                             const std::string &arch = "");
 
-std::unique_ptr<OperationPass<func::FuncOp>>
-createHloFusionToLinalgPass(llvm::StringRef anchorTag = "",
-                            bool enablePrimitiveOps = false);
+std::unique_ptr<OperationPass<func::FuncOp>> createHloFusionToLinalgPass(
+    llvm::StringRef anchorTag = "", bool enablePrimitiveOps = false,
+    const std::string &target = "", const std::string &arch = "");
 
 std::unique_ptr<OperationPass<func::FuncOp>> createUnrealizedCastToLinalgPass();
 

--- a/compiler/include/byteir/Pipelines/LinalgTensorOpt.h
+++ b/compiler/include/byteir/Pipelines/LinalgTensorOpt.h
@@ -30,6 +30,9 @@ struct LinalgTensorOptPipelineOptions
       *this, "target",
       llvm::cl::desc("An optional attribute to speicify target."),
       llvm::cl::init("")};
+  Option<std::string> arch{
+      *this, "arch", llvm::cl::desc("An optional attribute to speicify arch."),
+      llvm::cl::init("")};
 };
 
 void createLinalgTensorOptPipeline(

--- a/compiler/lib/Pipelines/LinalgTensorOpt.cpp
+++ b/compiler/lib/Pipelines/LinalgTensorOpt.cpp
@@ -228,9 +228,10 @@ void addGenericLinalgPasses(OpPassManager &pm) {
   }
 }
 
-void addCPULinalgOptPasses(OpPassManager &pm) {
+void addCPULinalgOptPasses(OpPassManager &pm, const std::string &target,
+                           const std::string &arch) {
   pm.addNestedPass<func::FuncOp>(createHloFusionToLinalgPass(
-      getByteIRHloAggressiveFusionAttrName(), true));
+      getByteIRHloAggressiveFusionAttrName(), true, target, arch));
   pm.addNestedPass<func::FuncOp>(createUnrealizedCastToLinalgPass());
   {
     TileAndVectorizeTransposeOptions options;
@@ -248,9 +249,10 @@ void addCPULinalgOptPasses(OpPassManager &pm) {
 }
 
 void createLinalgTensorOptPipelineImpl(OpPassManager &pm,
-                                       const std::string &target) {
+                                       const std::string &target,
+                                       const std::string &arch) {
   if (target == "cpu") {
-    addCPULinalgOptPasses(pm);
+    addCPULinalgOptPasses(pm, target, arch);
   } else {
     addGenericLinalgPasses(pm);
   }
@@ -260,5 +262,5 @@ void createLinalgTensorOptPipelineImpl(OpPassManager &pm,
 void mlir::createLinalgTensorOptPipeline(
     OpPassManager &pm, const LinalgTensorOptPipelineOptions &options) {
   invokeOpPassPipelineBuilder(createLinalgTensorOptPipelineImpl, pm,
-                              options.target);
+                              options.target, options.arch);
 }

--- a/compiler/python/byteir/compile.py
+++ b/compiler/python/byteir/compile.py
@@ -297,6 +297,7 @@ def _compile_cpu(
 
     entry_func_str = "entry-func={}".format(entry_func)
     target_str = "target={}".format(target)
+    arch_str="arch={}".format(cpu_arch)
     with context:
         PassManager().parse("builtin.module(hlo-graph-opt{" + entry_func_str + " " + target_str + "})").run(module.operation)
         _print_verbose(module, "// IR Dump After Hlo Graph Opt:") if verbose else ...
@@ -304,7 +305,7 @@ def _compile_cpu(
         PassManager().parse("builtin.module(hlo-fusion-opt{" + entry_func_str + " " + target_str + " outline-single-elemwise-op})").run(module.operation)
         _print_verbose(module, "// IR Dump After Hlo Fusion Opt:") if verbose else ...
     with context:
-        PassManager.parse("builtin.module(linalg-tensor-opt{" + target_str + "})").run(module.operation)
+        PassManager.parse("builtin.module(linalg-tensor-opt{" + target_str + " " + arch_str + "})").run(module.operation)
         _print_verbose(module, "// IR Dump After Linalg Tensor Opt:") if verbose else ...
     with context:
         PassManager.parse("builtin.module(byre-tensor-opt{{append-arg-types {}}})".format(entry_func_str)).run(module.operation)

--- a/compiler/test/Conversion/ToLinalg/hloConvertToLinalg.mlir
+++ b/compiler/test/Conversion/ToLinalg/hloConvertToLinalg.mlir
@@ -1,0 +1,11 @@
+// RUN: byteir-opt %s -hlo-fusion-to-linalg="target="cpu" arch="x86_64"" | FileCheck %s
+
+func.func @mhlo_convert_f32_i32(%arg0: tensor<2x3xf32>) -> tensor<2x3xi32> {
+    %0 = mhlo.convert %arg0 : (tensor<2x3xf32>) -> tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+}
+// CHECK-LABEL: mhlo_convert_f32_i32
+// CHECK: linalg.map
+// CHECK: arith.cmpf
+// CHECK: arith.fptosi
+// CHECK: arith.select

--- a/tests/numerical_test/execute.py
+++ b/tests/numerical_test/execute.py
@@ -33,6 +33,9 @@ np.random.seed(0)
 MLIR_TEST_SPECIAL_INPUTS = {
     "cpu@log_plus_one.mlir": [
         np.random.uniform(low=0.5, high=1.0, size=(256, 64)).astype(np.float16)
+    ],
+    "cpu@convert_f32_i32_special_val.mlir": [
+        np.array([[np.inf, -np.inf, np.nan], [1., 999.999, -np.inf]], dtype=np.float32),
     ]
 }
 

--- a/tests/numerical_test/mlir_tests/cpu_ops/convert_f32_i32_special_val.mlir
+++ b/tests/numerical_test/mlir_tests/cpu_ops/convert_f32_i32_special_val.mlir
@@ -1,0 +1,4 @@
+func.func @convert_f32_i32_special_val(%arg0 : tensor<2x3xf32>) -> tensor<2x3xi32> { 
+  %0 = stablehlo.convert %arg0 : (tensor<2x3xf32>) -> tensor<2x3xi32>
+  func.return %0 : tensor<2x3xi32>
+}


### PR DESCRIPTION
1. on x86_64, [inf, -inf, nan] will be converted to [INT32_MIN, INT32_MIN, INT32_MIN] due to UB. However, on arm_aarch64/nvgpu, [inf, -inf, nan] will be converted to [INT32_MAX, INT32_MIN, 0].
2. so we add compare and select during HloToLinalg and add target & arch option to control it.
