### PR TITLE
[compiler] fix remove copy max iteration error.

### DIFF
--- a/compiler/lib/Dialect/MemRef/Transforms/RemoveCopy.cpp
+++ b/compiler/lib/Dialect/MemRef/Transforms/RemoveCopy.cpp
@@ -414,6 +414,7 @@ public:
     // Use TopDownTraversal for compile time reasons
     GreedyRewriteConfig grc;
     grc.useTopDownTraversal = true;
+    grc.maxIterations = 20;
     if (failed(applyPatternsAndFoldGreedily(funcOp, frozenPatterns, grc))) {
       signalPassFailure();
     }


### PR DESCRIPTION
this pass tries to remove redundant copyOp. When some of these copyOps have W.R deps, the max number of iterations would lgt the default(10) value. Just set to 20 to bypass the current cases.

TODO: solve this issue more generally.