### PR TITLE
[torch-frontend] fix lowering of aten.expand_as

### DIFF
--- a/frontends/torch-frontend/torch-frontend/lib/Conversion/ConvertTorchToStablehloExt.cpp
+++ b/frontends/torch-frontend/torch-frontend/lib/Conversion/ConvertTorchToStablehloExt.cpp
@@ -333,13 +333,14 @@ struct ConvertAtenExpandAsOp : public OpConversionPattern<AtenExpandAsOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Value lhs = adaptor.getSelf();
     Value rhs = adaptor.getOther();
-    int64_t rank = cast<RankedTensorType>(rhs.getType()).getRank();
+    int64_t lhs_rank = cast<RankedTensorType>(lhs.getType()).getRank();
+    int64_t rhs_rank = cast<RankedTensorType>(rhs.getType()).getRank();
 
     Value shape = rewriter.create<shape::ShapeOfOp>(op->getLoc(), rhs);
     Value result = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
         op->getLoc(), rhs.getType(), lhs, shape,
-        rewriter.getDenseI64ArrayAttr(
-            llvm::to_vector(llvm::seq<int64_t>(0, rank))));
+        rewriter.getDenseI64ArrayAttr(llvm::to_vector(
+            llvm::seq<int64_t>(rhs_rank - lhs_rank, rhs_rank))));
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_ops.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_ops.py
@@ -309,3 +309,27 @@ def test_tuple_one_tensor():
     inputs = [tu.randn(3, 4)]
     module = compile(Tuple2Module(), inputs, "stablehlo")
     print(module.operation.get_asm())
+
+# ==============================================================================
+# expand_as
+
+def ExpandAsModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x, y, z):
+        return x.expand_as(y), x.expand_as(z)
+
+def ExpandAsModule1(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x, y):
+        return x.expand_as(y)
+
+def test_expand_as():
+    inputs = [tu.randn(3, 1), tu.randn(3, 4), tu.randn(2, 2, 3, 4)]
+    module = compile(ExpandAsModule(), inputs, "stablehlo")
+    numerical_test_helper(module, inputs, ExpandAsModule()(*inputs))
+
+    inputs = [tu.tensor(1.0), tu.randn(3, 4)]
+    module = compile(ExpandAsModule1(), inputs, "stablehlo")
+    numerical_test_helper(module, inputs, ExpandAsModule1()(*inputs))

--- a/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_ops.py
+++ b/frontends/torch-frontend/torch-frontend/python/test/test_torchscript/test_ops.py
@@ -313,13 +313,13 @@ def test_tuple_one_tensor():
 # ==============================================================================
 # expand_as
 
-def ExpandAsModule(torch.nn.Module):
+class ExpandAsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
     def forward(self, x, y, z):
         return x.expand_as(y), x.expand_as(z)
 
-def ExpandAsModule1(torch.nn.Module):
+class ExpandAsModule1(torch.nn.Module):
     def __init__(self):
         super().__init__()
     def forward(self, x, y):


### PR DESCRIPTION
* support expand: (3, 1) => (3, 4) && (3, 1) => (2, 2, 3, 4) && (,) => (3, 4)