### PR TITLE
[compiler] support merge two modules by mapping

### DIFF
--- a/compiler/include/byteir-c/Translation.h
+++ b/compiler/include/byteir-c/Translation.h
@@ -46,7 +46,8 @@ MLIR_CAPI_EXPORTED MlirModule byteirDeserializeByre(MlirStringRef artifactStr,
 
 MLIR_CAPI_EXPORTED MlirModule byteirMergeTwoModules(MlirModule module0,
                                                     MlirModule module1,
-                                                    bool skipNameCheck);
+                                                    const void *mappingData,
+                                                    size_t mappingLength);
 
 #ifdef __cplusplus
 }

--- a/compiler/include/byteir/Utils/ModuleUtils.h
+++ b/compiler/include/byteir/Utils/ModuleUtils.h
@@ -39,9 +39,11 @@ constexpr llvm::StringRef getByteIREntryPointName() {
 // 3. if there are `byteir.entry_point` in only one module, return std::nullopt
 // 4. check arguments' shape and dtype on the border
 OwningOpRef<ModuleOp> mergeTwoModulesByNameOrOrder(ModuleOp module0,
-                                                   ModuleOp module1,
-                                                   bool skipNameCheck = false);
+                                                   ModuleOp module1);
 
+OwningOpRef<ModuleOp> mergeTwoModulesByMapping(ModuleOp module0,
+                                               ModuleOp module1,
+                                               llvm::ArrayRef<int64_t> mapping);
 } // namespace mlir
 
 #endif // BYTEIR_UTILS_MODULEUTILS_H

--- a/compiler/lib/CAPI/Translation.cpp
+++ b/compiler/lib/CAPI/Translation.cpp
@@ -167,8 +167,16 @@ MlirModule byteirDeserializeByre(MlirStringRef artifactStr,
 }
 
 MlirModule byteirMergeTwoModules(MlirModule module0, MlirModule module1,
-                                 bool skipNameCheck) {
-  auto m = mergeTwoModulesByNameOrOrder(unwrap(module0), unwrap(module1),
-                                        skipNameCheck);
-  return {m.release()};
+                                 const void *mappingData,
+                                 size_t mappingLength) {
+  if (mappingLength == 0) {
+    auto m = mergeTwoModulesByNameOrOrder(unwrap(module0), unwrap(module1));
+    return {m.release()};
+  } else {
+    llvm::ArrayRef<int64_t> mapping(static_cast<const int64_t *>(mappingData),
+                                    mappingLength);
+    auto m =
+        mergeTwoModulesByMapping(unwrap(module0), unwrap(module1), mapping);
+    return {m.release()};
+  }
 }

--- a/compiler/python/ByteIRModules.cpp
+++ b/compiler/python/ByteIRModules.cpp
@@ -26,6 +26,9 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
+#include <cstdint>
+#include <vector>
+
 namespace py = pybind11;
 
 template <class Func, typename... Args>
@@ -300,8 +303,9 @@ PYBIND11_MODULE(_byteir, m) {
   m.def(
       "merge_two_modules",
       [](MlirModule module0, MlirModule module1,
-         bool skipNameCheck) -> MlirModule {
-        auto module = byteirMergeTwoModules(module0, module1, skipNameCheck);
+         std::vector<int64_t> mapping) -> MlirModule {
+        auto module = byteirMergeTwoModules(module0, module1, mapping.data(),
+                                            mapping.size());
         if (mlirModuleIsNull(module)) {
           PyErr_SetString(PyExc_ValueError, "failed to merge two modules");
           return {};
@@ -309,7 +313,7 @@ PYBIND11_MODULE(_byteir, m) {
         return module;
       },
       py::arg("module0"), py::arg("module1"),
-      py::arg("skip_name_check") = false);
+      py::arg("mapping") = std::vector<int64_t>{});
 
   m.def(
       "register_pdl_constraint_fn",

--- a/compiler/python/test/api/test_py_api.py
+++ b/compiler/python/test/api/test_py_api.py
@@ -34,13 +34,41 @@ def test_compile_mlp_inference_cpu_mlirbc():
 # test merge two modules
 
 def test_merge_two_modules():
+    path0 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase0.mlir"
+    path1 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase0_1.mlir"
+    context = ir.Context()
+    context.allow_unregistered_dialects = True
+    module0 = ir.Module.parse(open(path0, 'r').read(), context)
+    module1 = ir.Module.parse(open(path1, 'r').read(), context)
+    module2 = byteir.merge_two_modules(module0, module1)
+    print(module2.operation.get_asm())
+
+    path0 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase1.mlir"
+    path1 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase1_1.mlir"
+    context = ir.Context()
+    context.allow_unregistered_dialects = True
+    module0 = ir.Module.parse(open(path0, 'r').read(), context)
+    module1 = ir.Module.parse(open(path1, 'r').read(), context)
+    module2 = byteir.merge_two_modules(module0, module1)
+    print(module2.operation.get_asm())
+
+def test_merge_two_modules_with_mapping():
     path0 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase2.mlir"
     path1 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase2_1.mlir"
     context = ir.Context()
     context.allow_unregistered_dialects = True
     module0 = ir.Module.parse(open(path0, 'r').read(), context)
     module1 = ir.Module.parse(open(path1, 'r').read(), context)
-    module2 = byteir.merge_two_modules(module0, module1, skip_name_check=True)
+    module2 = byteir.merge_two_modules(module0, module1, [0, 1])
+    print(module2.operation.get_asm())
+
+    path0 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase2.mlir"
+    path1 = TEST_ROOT_DIR + "Utils/testMergeTwoModulesCase2_1.mlir"
+    context = ir.Context()
+    context.allow_unregistered_dialects = True
+    module0 = ir.Module.parse(open(path0, 'r').read(), context)
+    module1 = ir.Module.parse(open(path1, 'r').read(), context)
+    module2 = byteir.merge_two_modules(module0, module1, [0, -1])
     print(module2.operation.get_asm())
 
 # ==============================================================================


### PR DESCRIPTION
as title  
mapping argument describe how func0's outputs map to func1's inputs
* example1: func0 and func1 one-one mapping => [0, 1, 2, ....]
* example2: func0's first and second output mapping to func1 => [1, 0, -1]