### PR TITLE
Fix missing override function signature with __half in oprands or parameter

### DIFF
--- a/runtime/test/backends/cuda/providers/default/kernel/flash_attn_bwd_test.cc
+++ b/runtime/test/backends/cuda/providers/default/kernel/flash_attn_bwd_test.cc
@@ -47,6 +47,22 @@ using namespace brt;
 using namespace brt::cuda;
 using namespace brt::test;
 
+namespace {
+__half abs(__half value) {
+  return __float2half(std::fabs(__half2float(
+      value))); // Convert to float, apply fabs, convert back to __half
+}
+
+std::ostream &operator<<(std::ostream &os, const __half &value) {
+  // convert __half to float and print
+  return os << __half2float(value);
+}
+
+bool operator>(const __half &a, float b) {
+  return __half2float(a) > b; // convert __half to float and compare
+}
+} // namespace
+
 TEST(SM80CUDATestFlashAttnBwd, Basic) {
 
   size_t b = 1;

--- a/runtime/test/backends/cuda/providers/default/kernel/flash_attn_fwd_test.cc
+++ b/runtime/test/backends/cuda/providers/default/kernel/flash_attn_fwd_test.cc
@@ -41,6 +41,22 @@ using namespace brt;
 using namespace brt::cuda;
 using namespace brt::test;
 
+namespace {
+__half abs(__half value) {
+  return __float2half(std::fabs(__half2float(
+      value))); // Convert to float, apply fabs, convert back to __half
+}
+
+std::ostream &operator<<(std::ostream &os, const __half &value) {
+  // convert __half to float and print
+  return os << __half2float(value);
+}
+
+bool operator>(const __half &a, float b) {
+  return __half2float(a) > b; // convert __half to float and compare
+}
+} // namespace
+
 TEST(SM80CUDATestFlashAttnFwd, Basic) {
 
   size_t b = 1;


### PR DESCRIPTION
Missing override function signature with __half(cuda fp16) in oprands or parameter incurs compilation error while build brt_cuda. The corresponding functions are added to ensure it compiles successfully.