### PR TITLE
[compiler] remove shape infer function for tf.BatchMatMul and tf.StridedSlice

### DIFF
--- a/compiler/include/byteir/Dialect/mhlo/DynamicShapeOpRegister/Register.h
+++ b/compiler/include/byteir/Dialect/mhlo/DynamicShapeOpRegister/Register.h
@@ -55,8 +55,8 @@ inline void registerAllMhloInferReturnTypeComponents() {
   registerTorchIndexSelectInferReturnTypeComponents();
   registerGeLUInferReturnTypeComponents();
   registerLayerNormInferReturnTypeComponents();
-  registerBatchMatMulInferReturnTypeComponents();
-  registerStridedSliceInferReturnTypeComponents();
+  // registerBatchMatMulInferReturnTypeComponents();
+  // registerStridedSliceInferReturnTypeComponents();
 }
 
 //===----------------------------------------------------------------------===//
@@ -72,7 +72,7 @@ inline void registerAllMhloInferBoundedReturnTypeComponents() {
   registerDynamicPartitionInferBoundedReturnTypeComponents();
   registerNonZeroInferBoundedReturnTypeComponents();
   registerScatterNdInferBoundedReturnTypeComponents();
-  registerStridedSliceInferBoundedReturnTypeComponents();
+  // registerStridedSliceInferBoundedReturnTypeComponents();
   registerRepeatInferBoundedReturnTypeComponents();
 }
 
@@ -96,7 +96,7 @@ inline void registerAllMhloReifyReturnTypeShapes() {
   registerSoftmaxReifyReturnTypeShapes();
   registerTorchIndexSelectReifyReturnTypeShapes();
   registerGeLUReifyReturnTypeShapes();
-  registerStridedSliceReifyReturnTypeShapes();
+  // registerStridedSliceReifyReturnTypeShapes();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/test/Transforms/boundedShapeInference.mlir
+++ b/compiler/test/Transforms/boundedShapeInference.mlir
@@ -118,29 +118,3 @@ func.func @gelu(%arg0: tensor<?x3072xf32> {byteir.bounded_shape = [1500, 3072]})
   return %0 : tensor<?x3072xf32>
 }
 // CHECK-LABEL:  func.func @gelu(%arg0: tensor<?x3072xf32, {byteir.bounded_shape = [1500, 3072]}> {byteir.bounded_shape = [1500, 3072]}) -> tensor<?x3072xf32, {byteir.bounded_shape = [1500, 3072]}>
-
-func.func @tf_StridedSlice(%arg0 : tensor<?x60x16xf16> {byteir.bounded_shape = [50, 60, 16]}) -> tensor<?x60x16xf16> {
-  %0 = mhlo.constant dense<11> : tensor<1xi32>
-  %1 = mhlo.constant dense<1> : tensor<1xi32>
-  %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %1, %0, %1) {backend_config = "", byteir_attrs = {begin_mask = 0 : i64, ellipsis_mask = 0 : i64, end_mask = 0 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64}} : (tensor<?x60x16xf16>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?x60x16xf16>
-  return %2 : tensor<?x60x16xf16>
-}
-// CHECK-LABEL: func.func @tf_StridedSlice(%arg0: tensor<?x60x16xf16, {byteir.bounded_shape = [50, 60, 16]}> {byteir.bounded_shape = [50, 60, 16]}) -> tensor<?x60x16xf16, {byteir.bounded_shape = [10, 60, 16]}> {
-// CHECK-NEXT:    %0 = mhlo.constant dense<11> : tensor<1xi32>
-// CHECK-NEXT:    %1 = mhlo.constant dense<1> : tensor<1xi32>
-// CHECK-NEXT:    %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %1, %0, %1) {backend_config = "", byteir_attrs = {begin_mask = 0 : i64, ellipsis_mask = 0 : i64, end_mask = 0 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64}} : (tensor<?x60x16xf16, {byteir.bounded_shape = [50, 60, 16]}>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?x60x16xf16, {byteir.bounded_shape = [10, 60, 16]}>
-// CHECK-NEXT:    return %2 : tensor<?x60x16xf16, {byteir.bounded_shape = [10, 60, 16]}>
-// CHECK-NEXT:  }
-
-func.func @tf_StridedSlice_NewAxis(%arg0 : tensor<?x5x64xf16> {byteir.bounded_shape = [50, 5, 64]}) -> tensor<?x5x1x64xf16> {
-  %0 = mhlo.constant dense<0> : tensor<4xi32>
-  %1 = mhlo.constant dense<1> : tensor<4xi32>
-  %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %0, %0, %1) {backend_config = "", byteir_attrs = {begin_mask = 11 : i64, ellipsis_mask = 0 : i64, end_mask = 11 : i64, new_axis_mask = 4 : i64, shrink_axis_mask = 0 : i64}} : (tensor<?x5x64xf16>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) -> tensor<?x5x1x64xf16>
-  return %2 : tensor<?x5x1x64xf16>
-}
-// CHECK-LABEL: func.func @tf_StridedSlice_NewAxis(%arg0: tensor<?x5x64xf16, {byteir.bounded_shape = [50, 5, 64]}> {byteir.bounded_shape = [50, 5, 64]}) -> tensor<?x5x1x64xf16, {byteir.bounded_shape = [50, 5, 1, 64]}> {
-// CHECK-NEXT:    %0 = mhlo.constant dense<0> : tensor<4xi32>
-// CHECK-NEXT:    %1 = mhlo.constant dense<1> : tensor<4xi32>
-// CHECK-NEXT:    %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %0, %0, %1) {backend_config = "", byteir_attrs = {begin_mask = 11 : i64, ellipsis_mask = 0 : i64, end_mask = 11 : i64, new_axis_mask = 4 : i64, shrink_axis_mask = 0 : i64}} : (tensor<?x5x64xf16, {byteir.bounded_shape = [50, 5, 64]}>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) -> tensor<?x5x1x64xf16, {byteir.bounded_shape = [50, 5, 1, 64]}>
-// CHECK-NEXT:    return %2 : tensor<?x5x1x64xf16, {byteir.bounded_shape = [50, 5, 1, 64]}>
-// CHECK-NEXT:  }

--- a/compiler/test/Transforms/shapeReification.mlir
+++ b/compiler/test/Transforms/shapeReification.mlir
@@ -62,24 +62,6 @@ func.func @gelu(%arg0: tensor<?x3072xf32>) -> tensor<?x3072xf32> {
   return %0 : tensor<?x3072xf32>
 }
 
-func.func @tf_StridedSlice(%arg0: tensor<?x5x64xf16>) -> tensor<?x5x1x64xf16> {
-  %0 = mhlo.constant dense<1> : tensor<4xi32>
-  %1 = mhlo.constant dense<0> : tensor<4xi32>
-  %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %1, %1, %0) {backend_config = "", byteir_attrs = {begin_mask = 11 : i64, ellipsis_mask = 0 : i64, end_mask = 11 : i64, new_axis_mask = 4 : i64, shrink_axis_mask = 0 : i64}} : (tensor<?x5x64xf16>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) -> tensor<?x5x1x64xf16>
-  %cst = arith.constant 0 : index
-  %dim = tensor.dim %2, %cst : tensor<?x5x1x64xf16>
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[C1:.*]] = arith.constant -1 : index
-  // CHECK-DAG: %[[C2:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[DIM:.*]] = tensor.dim %arg0, %[[C0]] : tensor<?x5x64xf16>
-  // CHECK-DAG: %[[V0:.*]] = shape.add %[[DIM]], %[[C1]] : index, index -> index
-  // CHECK-DAG: %[[V1:.*]] = shape.div %[[V0]], %[[C2]] : index, index -> index
-  // CHECK-DAG: %[[V2:.*]] = shape.add %[[V1]], %[[C2]] : index, index -> index
-  // CHECK-DAG: "shape_ext.tie"(%2, %[[V2]]) : (tensor<?x5x1x64xf16>, index) -> ()
-  "shape_ext.tie"(%2, %dim) : (tensor<?x5x1x64xf16>, index) -> ()
-  return %2 : tensor<?x5x1x64xf16>
-}
-
 // CHECK-LABEL: func.func @dot_general
 func.func @dot_general(%arg0: tensor<?x?x4xf32>, %arg1: tensor<?x4x128xf32>) -> tensor<3xindex> {
   %c1 = arith.constant 1 : index

--- a/compiler/test/Transforms/staticShapeInference.mlir
+++ b/compiler/test/Transforms/staticShapeInference.mlir
@@ -47,13 +47,3 @@ func.func @several_ops(%arg0: tensor<?x4xf32> {byteir.static_shape = [8, 4]}, %a
   return %3 : tensor<?x4xf32>
 // CHECK-NEXT: return %2 : tensor<8x4xf32>
 }
-
-// CHECK-LABEL: func.func @tf_StridedSlice(%arg0: tensor<50x60x16xf16>) -> tensor<10x60x16xf16> {
-func.func @tf_StridedSlice(%arg0 : tensor<50x60x16xf16>) -> tensor<?x60x16xf16> {
-  %0 = mhlo.constant dense<11> : tensor<1xi32>
-  %1 = mhlo.constant dense<1> : tensor<1xi32>
-// CHECK: %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %1, %0, %1) {backend_config = "", byteir_attrs = {begin_mask = 0 : i64, ellipsis_mask = 0 : i64, end_mask = 0 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64}} : (tensor<50x60x16xf16>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<10x60x16xf16>
-  %2 = mhlo.custom_call @tf.StridedSlice(%arg0, %1, %0, %1) {backend_config = "", byteir_attrs = {begin_mask = 0 : i64, ellipsis_mask = 0 : i64, end_mask = 0 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64}} : (tensor<50x60x16xf16>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?x60x16xf16>
-// CHECK-NEXT: return %2 : tensor<10x60x16xf16>
-  return %2 : tensor<?x60x16xf16>
-}

--- a/frontends/tf-frontend/tf_mlir_ext/tests/mhlo_legalize_tf_ext.mlir
+++ b/frontends/tf-frontend/tf_mlir_ext/tests/mhlo_legalize_tf_ext.mlir
@@ -62,6 +62,16 @@ func.func @negative_stride_indice_StridedSlice(%arg0: tensor<10x20x30x40x50x60xf
 // CHECK: mhlo.slice
 // CHECK: mhlo.reshape
 
+func.func @remove_StridedSlice(%arg0: tensor<2x34xi32>) -> tensor<2x34xi32> {
+  %0 = "tf.Const"() <{value = dense<[63, 63]> : tensor<2xi32>}> : () -> tensor<2xi32>
+  %1 = "tf.Const"() <{value = dense<[0, 63]> : tensor<2xi32>}> : () -> tensor<2xi32>
+  %2 = "tf.Const"() <{value = dense<1> : tensor<2xi32>}> : () -> tensor<2xi32>
+  %3 = "tf.StridedSlice"(%arg0, %0, %1, %2) <{begin_mask = 3 : i64, ellipsis_mask = 0 : i64, end_mask = 1 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64}> {device = ""} : (tensor<2x34xi32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<2x34xi32>
+  return %3 : tensor<2x34xi32>
+}
+// CHECK-LABEL: remove_StridedSlice
+// CHECK: return %arg0 : tensor<2x34xi32>
+
 func.func @dynamic_shape_to_sataic_shapeStridedSlice(%arg0: tensor<?x?x40xf16>) -> tensor<11x2x40xf16> {
   %0 = "tf.Const"() {value = dense<[2, 6, 100]>: tensor<3xi32>} : () -> tensor<3xi32>
   %1 = "tf.Const"() {value = dense<[11, 8, 99]> : tensor<3xi32>} : () -> tensor<3xi32>

--- a/frontends/tf-frontend/tf_mlir_ext/transforms/mhlo_legalize_tf_ext.cc
+++ b/frontends/tf-frontend/tf_mlir_ext/transforms/mhlo_legalize_tf_ext.cc
@@ -132,6 +132,7 @@ public:
         std::holds_alternative<int64_t>(dimSizeOr)) {
       int64_t index = std::get<int64_t>(indexOr);
       int64_t dimSize = std::get<int64_t>(dimSizeOr);
+      index = (index > dimSize) ? dimSize : index;
       if (reverse) {
         return (index >= 0) ? (dimSize - 1 - index) : (-1 - index);
       } else {


### PR DESCRIPTION
1. [tf-frontend] fix for tf.StridedSlice
2. [compiler] remove shape infer function for tf.BatchMatMul and tf.StridedSlice